### PR TITLE
Fix the health check problem during the service start-up

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,0 +1,2 @@
+ignore_files:
+  - lib/charms/nginx_ingress_integrator/v0/ingress.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,8 @@ docstring-convention = "google"
 copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks slow and not very important tests"
+]

--- a/src/charm.py
+++ b/src/charm.py
@@ -680,9 +680,10 @@ class WordpressCharm(CharmBase):
     def _check_addon_type(self, addon_type):
         """Check if addon_type is one of the accepted addon types (theme/plugin).
 
-        Raise a AssertError if not.
+        Raise a ValueError if not.
         """
-        assert addon_type in ("theme", "plugin")
+        if addon_type not in ("theme", "plugin"):
+            raise ValueError(f"Addon type unknown {repr(addon_type)}, accept: (theme, plugin)")
 
     def _wp_addon_list(self, addon_type):
         """List all installed WordPress addons.
@@ -855,7 +856,10 @@ class WordpressCharm(CharmBase):
         Returns:
             An instance of :attr:`charm.WordpressCharm._ExecResult`.
         """
-        assert action in ("activate", "deactivate")
+        if action not in ("activate", "deactivate"):
+            raise ValueError(
+                f"Unknown activation_status {repr(action)}, " "accept (activate, deactivate)"
+            )
         current_plugins = self._wp_addon_list("plugin")
         if not current_plugins.success:
             return self._ExecResult(

--- a/src/charm.py
+++ b/src/charm.py
@@ -586,6 +586,9 @@ class WordpressCharm(CharmBase):
                 if self._wp_is_installed():
                     break
                 else:
+                    self.unit.status = WaitingStatus(
+                        "Waiting for leader unit to initialize database"
+                    )
                     time.sleep(5)
             else:
                 raise exceptions.WordPressBlockedStatusException(
@@ -594,7 +597,7 @@ class WordpressCharm(CharmBase):
         if self._current_wp_config() is None:
             # For security reasons, never start WordPress server if wp-config.php not exists
             raise FileNotFoundError(
-                "required file (wp-config.php) for starting WordPress server not exists"
+                "required file (wp-config.php) for starting WordPress server does not exists"
             )
         self._init_pebble_layer()
         if not self._container().get_service(self._SERVICE_NAME).is_running():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,7 +17,8 @@ import kubernetes
 import pytest
 import pytest_asyncio
 import pytest_operator.plugin
-from wordpress_client_for_test import WordpressClient
+
+from tests.integration.wordpress_client_for_test import WordpressClient
 
 
 @pytest_asyncio.fixture(scope="function", name="app_config")

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -17,9 +17,9 @@ import requests
 import swiftclient
 import swiftclient.exceptions
 import swiftclient.service
-from wordpress_client_for_test import WordpressClient
 
 from charm import WordpressCharm
+from tests.integration.wordpress_client_for_test import WordpressClient
 
 
 @pytest.mark.asyncio
@@ -151,6 +151,7 @@ async def test_wordpress_default_themes(unit_ip_list, get_theme_list_from_ip):
         ), "default themes installed should match default themes defined in WordpressCharm"
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_wordpress_install_uninstall_themes(
     ops_test: pytest_operator.plugin.OpsTest,
@@ -183,6 +184,7 @@ async def test_wordpress_install_uninstall_themes(
             ), f"theme installed {themes} should match themes setting in config"
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_wordpress_theme_installation_error(
     ops_test: pytest_operator.plugin.OpsTest, application_name
@@ -215,6 +217,7 @@ async def test_wordpress_theme_installation_error(
         ), "status should back to active after invalid theme removed from config"
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_wordpress_install_uninstall_plugins(
     ops_test: pytest_operator.plugin.OpsTest,
@@ -246,6 +249,7 @@ async def test_wordpress_install_uninstall_plugins(
             ), f"plugin installed {plugins} should match plugins setting in config"
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_wordpress_plugin_installation_error(
     ops_test: pytest_operator.plugin.OpsTest, application_name

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -602,9 +602,16 @@ def test_ingress(
     }
 
 
-def test_defensive_programing(
-    harness: ops.testing.Harness,
-):
+@pytest.mark.parametrize(
+    "method,test_args",
+    [
+        ("_wp_addon_install", ("not theme/plugin", "name")),
+        ("_wp_addon_list", ("not theme/plugin",)),
+        ("_wp_addon_uninstall", ("not theme/plugin", "name")),
+        ("_perform_plugin_activate_or_deactivate", ("name", "not activate/deactivate")),
+    ],
+)
+def test_defensive_programing(harness: ops.testing.Harness, method: str, test_args: list):
     """
     arrange: no arrange.
     act: invoke some method with incorrect arguments.
@@ -612,10 +619,4 @@ def test_defensive_programing(
     """
     harness.begin()
     with pytest.raises(ValueError):
-        harness.charm._wp_addon_install("not theme/plugin", "name")
-    with pytest.raises(ValueError):
-        harness.charm._wp_addon_list("not theme/plugin")
-    with pytest.raises(ValueError):
-        harness.charm._wp_addon_uninstall("not theme/plugin", "name")
-    with pytest.raises(ValueError):
-        harness.charm._perform_plugin_activate_or_deactivate("", "not activate/deactivate")
+        getattr(harness.charm, method)(*test_args)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -569,7 +569,7 @@ def test_ingress(
     app_name: str,
 ):
     """
-    arrange: after peer relation established and database ready
+    arrange: after peer relation established and database ready.
     act: create a relation between wordpress and nginx ingress integrator, and update the
         tls_secret_name configuration.
     assert: ingress relation data should be set up according to the configuration and application
@@ -600,3 +600,22 @@ def test_ingress(
         "service-port": "80",
         "tls-secret-name": "tls_secret",
     }
+
+
+def test_defensive_programing(
+    harness: ops.testing.Harness,
+):
+    """
+    arrange: no arrange.
+    act: invoke some method with incorrect arguments.
+    assert: ValueError should be raised to prevent further execution.
+    """
+    harness.begin()
+    with pytest.raises(ValueError):
+        harness.charm._wp_addon_install("not theme/plugin", "name")
+    with pytest.raises(ValueError):
+        harness.charm._wp_addon_list("not theme/plugin")
+    with pytest.raises(ValueError):
+        harness.charm._wp_addon_uninstall("not theme/plugin", "name")
+    with pytest.raises(ValueError):
+        harness.charm._perform_plugin_activate_or_deactivate("", "not activate/deactivate")


### PR DESCRIPTION
The current charm version start-up sequence is:

1. add the layer to pebble
2. initialize the WordPress database
3. start the web server

So when the readiness check defined in the pebble layer was added, the server is not started immediately. Sometimes the in-between steps will take more than 30 seconds, which will cause the health check to fail and Kubernetes will restart the container, causing a series of trouble.

Change the start-up sequence to avoid this problem:

1. initialize the WordPress database
2. add the layer to pebble
3. start the web server