### PR TITLE
fix: Open ID auth

### DIFF
--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -507,7 +507,6 @@ async def test_akismet_plugin(
 @pytest.mark.usefixtures("build_and_deploy")
 @pytest.mark.requires_secret
 @pytest.mark.asyncio
-@pytest.mark.skip
 async def test_openid_plugin(
     ops_test: pytest_operator.plugin.OpsTest,
     application_name,

--- a/tests/integration/wordpress_client_for_test.py
+++ b/tests/integration/wordpress_client_for_test.py
@@ -428,7 +428,7 @@ class WordpressClient:
         csrf_token = re.findall(
             "<input type='hidden' name='csrfmiddlewaretoken' value='([^']+)' />", confirm_page.text
         )[0]
-        team = re.findall(">Team membership: ([^<]+)<", confirm_page.text)[0]
+        team = re.findall("Team membership: ([^<]+)<", confirm_page.text)[0]
         self._post(
             confirm_page.url,
             data={

--- a/wordpress.Dockerfile
+++ b/wordpress.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG VERSION=5.9.3
 ENV APACHE_CONFDIR=/etc/apache2


### PR DESCRIPTION
This PR is to fix the failing test for OpenID plugin integration tests. It is simplified from #41 to unblock the non-passing CI first before committing to the bigger tests refactor.

The problems are in:
1. PHP version which is incompatible with wordpress-launchpad-integration, hence the Dockerfile's base image downgrade(to support php ver 7)
2. Updated Ubuntu One website, hence the regex fix