### PR TITLE
fix: pin kubernetes deps version

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -2,7 +2,7 @@ juju>=2,<3
 pytest
 Pillow
 requests
-kubernetes
+kubernetes>=25.3,<26
 pytest-cov
 types-requests
 pytest-operator


### PR DESCRIPTION
This PR addresses the failure in CI pipeline in [publishing to edge](https://github.com/canonical/wordpress-k8s-operator/actions/runs/4192305905/jobs/7268258858) caused by a kubernetes library major version update.
