### PR TITLE
fix: remove duplicate test w/ secrets

### DIFF
--- a/.github/workflows/integration_test_secrets.yaml
+++ b/.github/workflows/integration_test_secrets.yaml
@@ -3,10 +3,6 @@ name: Integration tests with secrets
 on:
   workflow_call:
     inputs:
-      images:
-        description: Existing docker images
-        type: string
-        default: '[""]'
       runs-on:
         type: string
         description: Image runner for building the images
@@ -17,8 +13,17 @@ env:
   OWNER: ${{ github.repository_owner }}
 
 jobs:
+  build-images:
+    name: Build images
+    uses: canonical/operator-workflows/.github/workflows/build_images.yaml@main
+    with:
+      owner: ${{ github.repository_owner }}
+      registry: ghcr.io
+      runs-on: ${{ inputs.runs-on }}
+      trivy-image-config: trivy.yaml
   integration-test-with-secrets:
     runs-on: ${{ inputs.runs-on }}
+    needs: [build-images]
     strategy:
       fail-fast: false
       matrix:
@@ -54,7 +59,7 @@ jobs:
       - name: Run integration tests
         run: |
           args=""
-          for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
+          for image_name in $(echo '${{ needs.build-images.outputs.images }}' | jq -cr '.[]'); do
             if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
               args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
             else

--- a/.github/workflows/integration_test_secrets.yaml
+++ b/.github/workflows/integration_test_secrets.yaml
@@ -3,6 +3,10 @@ name: Integration tests with secrets
 on:
   workflow_call:
     inputs:
+      images:
+        description: Existing docker images
+        type: string
+        default: '[""]'
       runs-on:
         type: string
         description: Image runner for building the images
@@ -13,17 +17,8 @@ env:
   OWNER: ${{ github.repository_owner }}
 
 jobs:
-  build-images:
-    name: Build images
-    uses: canonical/operator-workflows/.github/workflows/build_images.yaml@main
-    with:
-      owner: ${{ github.repository_owner }}
-      registry: ghcr.io
-      runs-on: ${{ inputs.runs-on }}
-      trivy-image-config: trivy.yaml
   integration-test-with-secrets:
     runs-on: ${{ inputs.runs-on }}
-    needs: [build-images]
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +54,7 @@ jobs:
       - name: Run integration tests
         run: |
           args=""
-          for image_name in $(echo '${{ needs.build-images.outputs.images }}' | jq -cr '.[]'); do
+          for image_name in $(echo '${{ inputs.images }}' | jq -cr '.[]'); do
             if [ ${{ github.event.pull_request.head.repo.fork }} = "true" ]; then
               args="${args} --${image_name}-image localhost:32000/${image_name}:latest"
             else

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -15,9 +15,6 @@ on:
       - track/**
 
 jobs:
-  integration-test-with-secrets:
-    uses: ./.github/workflows/integration_test_secrets.yaml
-    secrets: inherit
   integration-test:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit
@@ -34,7 +31,7 @@ jobs:
             value: "--num-units=3"
           - name: num_units=1, db_from_relation
             value: "--num-units=1"
-    needs: [integration-test, integration-test-with-secrets]
+    needs: [integration-test]
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
     with:
       trivy-image-config: trivy.yaml


### PR DESCRIPTION
The test_and_publish_charm action contains integration-test-with-secrets step. This is already included in regular integration_tests and can be safely removed.