### PR TITLE
chore: ci run minial integration test

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -19,19 +19,19 @@ jobs:
     uses: ./.github/workflows/integration_test.yaml
     secrets: inherit
   test-and-publish-charm:
-    strategy:
-      fail-fast: false
-      matrix:
-        args:
-          - name: num_units=3, db_from_config
-            value: "--test-db-from-config --num-units=3"
-          - name: num_units=1, db_from_config
-            value: "--test-db-from-config --num-units=1"
-          - name: num_units=3, db_from_relation
-            value: "--num-units=3"
-          - name: num_units=1, db_from_relation
-            value: "--num-units=1"
     needs: [integration-test]
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
     with:
+      integration-test-extra-arguments: |
+        -m "not (requires_secret)" \
+        --openstack-rc ${GITHUB_WORKSPACE}/openrc \
+        --kube-config ${GITHUB_WORKSPACE}/kube-config \
+        --screenshot-dir /tmp \
+        --num-units=1
+      integration-test-modules: '["test_core"]'
+      integration-test-pre-run-script: |
+        -c "sudo microk8s enable registry hostpath-storage
+          sudo microk8s kubectl -n kube-system rollout status -w deployment/hostpath-provisioner
+          sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config"
+      setup-devstack-swift: true
       trivy-image-config: trivy.yaml


### PR DESCRIPTION
This PR removes the matrix run of test-and-publish-charm action which runs on multiple combinations and thus also publishes multiple instances of wordpress-k8s charm.

Since the local integration_test workflow runs the full suite of integration tests(test with secrets, combinations of tests using matrices), running the full suite of tests in test-and-publish-charm action is not needed.
The tests swapped in place for the matrix test in test-and-publish-charm is the minimal core integration test suite for the sake of running the test and building docker images.
