### PR TITLE
fix: pass in secrets to action

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -21,6 +21,7 @@ jobs:
   test-and-publish-charm:
     needs: [integration-test]
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
+    secrets: inherit
     with:
       integration-test-extra-arguments: |
         -m "not (requires_secret)" \


### PR DESCRIPTION
This PR addresses the failing CI pipeline due to the secrets not being passed in and hence the check lib action failing.

[Failing action](https://github.com/canonical/wordpress-k8s-operator/actions/runs/4289290795/jobs/7473177000)
