### PR TITLE
docs: reference to stable

### DIFF
--- a/docs/explanation/containers.md
+++ b/docs/explanation/containers.md
@@ -1,7 +1,7 @@
 # Containers
 
 The core component of wordpress-k8s charm consists of a wordpress-k8s main workload container and a
-apache-prometheus-exporter sidecar container. Both services inside the containers are driven by
+`apache-prometheus-exporter` sidecar container. Both services inside the containers are driven by
 Pebble, a lightweight API-driven process supervisor that controls the lifecycle of a service.
 Learn more about pebble and its layer configurations [here](https://github.com/canonical/pebble).
 
@@ -26,8 +26,8 @@ in the repository. The settings are dynamically modified during runtime when the
 In order to enable monitoring of Apache server status, redirection to WordPress php for route
 `/server-status` is overridden in
 [`files/apache2.conf`](https://github.com/canonical/wordpress-k8s-operator/blob/main/files/docker-php-swift-proxy.conf).
-`/server-status` endpoint is accessed by `apache-exporter service` to convert and re-expose with
-open metrics compliant format for integration with prometheus_scrape interface.
+`/server-status` endpoint is accessed by `apache-exporter` service to convert and re-expose with
+open metrics compliant format for integration with `prometheus_scrape` interface.
 
 When a logging relation is joined, a promtail application is started via pebble which starts
 pushing Apache server logs to Loki. The configurations for Apache have been set up to stream logs
@@ -46,5 +46,5 @@ Golang client are exposed that are not part of the WordPress Apache’s metrics 
 ### charm
 
 This container is the main point of contact with the juju controller. It communicates with juju to
-run necessary charm code defined by the main src/charm.py. The source code is copied to the
+run necessary charm code defined by the main `src/charm.py`. The source code is copied to the
 `/var/lib/juju/agents/unit-UNIT_NAME/charm` directory.

--- a/docs/explanation/lifecycle-events.md
+++ b/docs/explanation/lifecycle-events.md
@@ -29,7 +29,7 @@ not already set.
 
 WordPress-k8s charm reacts to any configuration change and runs reconciliation between the current
 state and the desired state. See the list of
-[configurations](https://charmhub.io/wordpress-k8s/configure?channel=edge).
+[configurations](https://charmhub.io/wordpress-k8s/configure).
 
 ### wordpress_pebble_ready
 

--- a/docs/explanation/oci-image.md
+++ b/docs/explanation/oci-image.md
@@ -17,7 +17,7 @@ image during build step. The latest CLI php archive file from source is used.
 
 Currently, WordPress version 5.9.3 is used alongside Ubuntu 20.04 base image. The Ubuntu base image
 hasn't yet been upgraded to 22.04 due to an unsupported php version 8 for
-`wordpress-launchpad-integration` plugin(supported php version 7). All other plugins and themes use
+`wordpress-launchpad-integration` plugin (supported php version 7). All other plugins and themes use
 the latest stable version by default, downloaded from the source.
 
 ### apache-prometheus-exporter-image

--- a/docs/explanation/oci-image.md
+++ b/docs/explanation/oci-image.md
@@ -4,15 +4,16 @@
 
 The wordpress-image is custom built to include a default set of plugins and themes. The list of
 plugins and themes can be found at the reference section of the
-[documentation](https://charmhub.io/wordpress-k8s/docs/reference?channel=edge). Since WordPress is
+[documentation](https://charmhub.io/wordpress-k8s/docs/reference). Since WordPress is
 an application running on php, required libraries and dependencies are installed during the build
 process.
 
 WordPress application installation is done at runtime during database connection setup. This can
 happen during database relation changed, database relation joined or database config changed
 events.
-To facilitate the WordPress installation process, WordPress cli is embedded in the OCI image during
-build step. The latest cli php archive file from source is used.
+To facilitate the WordPress installation process,
+[WordPress CLI](https://make.wordpress.org/cli/handbook/guides/installing/) is embedded in the OCI
+image during build step. The latest CLI php archive file from source is used.
 
 Currently, WordPress version 5.9.3 is used alongside Ubuntu 20.04 base image. The Ubuntu base image
 hasn't yet been upgraded to 22.04 due to an unsupported php version 8 for
@@ -22,5 +23,5 @@ the latest stable version by default, downloaded from the source.
 ### apache-prometheus-exporter-image
 
 This is the image required for sidecar container apache-prometheus-exporter. Openly available image
-`bitnami/apache-exporter` is used. Read more about the image from the official Docker hub
+`bitnami/apache-exporter` is used. Read more about the image from the official Docker Hub
 [source](https://hub.docker.com/r/bitnami/apache-exporter/).

--- a/docs/explanation/oci-image.md
+++ b/docs/explanation/oci-image.md
@@ -4,7 +4,7 @@
 
 The wordpress-image is custom built to include a default set of plugins and themes. The list of
 plugins and themes can be found at the reference section of the
-[documentation](https://charmhub.io/wordpress-k8s/docs/reference). Since WordPress is
+[documentation](https://charmhub.io/wordpress-k8s/docs/reference-plugins). Since WordPress is
 an application running on php, required libraries and dependencies are installed during the build
 process.
 

--- a/docs/explanation/overview.md
+++ b/docs/explanation/overview.md
@@ -3,5 +3,5 @@
 The wordpress-k8s charm aims to provide core functionalities of WordPress with horizontally
 scalable architecture, leveraging its flexible capabilities enhanced by plugins. Operational
 capabilities are enhanced through integration with the
-Canonical Observability Stack([COS](https://charmhub.io/topics/canonical-observability-stack/))
+Canonical Observability Stack ([COS](https://charmhub.io/topics/canonical-observability-stack/))
 charms.

--- a/docs/explanation/relations.md
+++ b/docs/explanation/relations.md
@@ -20,7 +20,7 @@ Ingress interface provides external http/https access to the WordPress applicati
 additional capabilities depending on the ingress charm. The wordpress-k8s charm's ingress relation
 is best enhanced with the [nginx-ingress-integrator](https://charmhub.io/nginx-ingress-integrator)
 charm, providing additional capabilities such as ModSecurity enabled
-Web Application Firewall([WAF](https://docs.nginx.com/nginx-waf/)) through the wordpress-k8s charm
+Web Application Firewall ([WAF](https://docs.nginx.com/nginx-waf/)) through the wordpress-k8s charm
 configuration parameter `use_nginx_ingress_modsec`. The ingress relation interface is subject to
 renaming due to additional ingress interface definition supported by the Traefik charm.
 

--- a/docs/explanation/relations.md
+++ b/docs/explanation/relations.md
@@ -2,41 +2,40 @@
 
 ### Peer relations
 
-When deploying multiple replications of the wordpress-k8s charm applications, peer relations are
-set up to ensure synchronization of data among replications. Namely, secrets and admin credentials
-are shared among peers. See more about the secrets in the `rotate-wordpress-secrets` action of the
-reference [documentation](https://charmhub.io/wordpress-k8s/docs/reference?channel=edge).
+When deploying multiple replications of the wordpress-k8s charm, peer relations are set up to
+ensure synchronization of data among replications. Namely, secrets and admin credentials are shared
+among peers. See more about the secrets in the `rotate-wordpress-secrets` action of the
+[reference documentation](https://charmhub.io/wordpress-k8s/docs/reference).
 
 ### db
 
-Database relation is required for WordPress to become active. Any relation that can fulfill the
-mysql interface can be used to integrate WordPress. However, due to the lack of mysql charm for the
-k8s environment, database configuration parameters are exposed for non-k8s native integrations.
-Configuration replacements for db relation can be found in the reference documentation with the
-prefix `db_`.
+Database relation is required for the wordpress-k8s charm to become active. Any relation that can
+fulfill the `mysql` interface can be used to integrate with the wordpress-k8s charm. Database
+configuration parameters are also provided for non-k8s native integrations support. Configuration
+replacements for db relation can be found in the reference documentation with the prefix `db_`.
 
 ### ingress
 
 Ingress interface provides external http/https access to the WordPress application along with other
-additional capabilities depending on the ingress charm. WordPress ingress relation is best enhanced
-with the [nginx-ingress-integrator](https://charmhub.io/nginx-ingress-integrator) charm, providing
-additional capabilities such as ModSecurity enabled
-Web Application Firewall([WAF](https://docs.nginx.com/nginx-waf/)) through WordPress configuration
-parameter `use_nginx_ingress_modsec`. The ingress relation interface is subject to renaming due to
-additional ingress interface definition supported by the Traefik charm.
+additional capabilities depending on the ingress charm. The wordpress-k8s charm's ingress relation
+is best enhanced with the [nginx-ingress-integrator](https://charmhub.io/nginx-ingress-integrator)
+charm, providing additional capabilities such as ModSecurity enabled
+Web Application Firewall([WAF](https://docs.nginx.com/nginx-waf/)) through the wordpress-k8s charm
+configuration parameter `use_nginx_ingress_modsec`. The ingress relation interface is subject to
+renaming due to additional ingress interface definition supported by the Traefik charm.
 
 ### metrics-endpoint
 
-This interface is a part of the COS integration to enhance metrics observability. WordPress
-satisfies the `prometheus_scrape` interface as a provider by exposing Open Metrics compliant
+This interface is a part of the COS integration to enhance metrics observability. The wordpress-k8s
+charm satisfies the `prometheus_scrape` interface as a provider by exposing Open Metrics compliant
 `/metrics` endpoint. Requires [prometheus-k8s](https://charmhub.io/prometheus-k8s) charm. Learn
 more about COS [here](https://charmhub.io/topics/canonical-observability-stack).
 
 ### logging
 
-Logging relation is a part of the COS integration to enhance logging observability. The WordPress
-charm satisfies the loki_push_api by integrating promtail that pushes apache logs to Loki. Requires
-[loki-k8s](https://charmhub.io/loki-k8s) charm. Learn more about COS
+Logging relation is a part of the COS integration to enhance logging observability. The
+wordpress-k8s charm satisfies the loki_push_api by integrating promtail that pushes apache logs to
+Loki. Requires [loki-k8s](https://charmhub.io/loki-k8s) charm. Learn more about COS
 [here](https://charmhub.io/topics/canonical-observability-stack).
 
 ### grafana-dashboard

--- a/docs/explanation/relations.md
+++ b/docs/explanation/relations.md
@@ -5,7 +5,7 @@
 When deploying multiple replications of the wordpress-k8s charm, peer relations are set up to
 ensure synchronization of data among replications. Namely, secrets and admin credentials are shared
 among peers. See more about the secrets in the `rotate-wordpress-secrets` action of the
-[reference documentation](https://charmhub.io/wordpress-k8s/docs/reference).
+[reference documentation](https://charmhub.io/wordpress-k8s/docs/reference-actions).
 
 ### db
 

--- a/docs/how-to-guides/initial-configuration.md
+++ b/docs/how-to-guides/initial-configuration.md
@@ -5,7 +5,7 @@ value afterwards has no effect.
 
 By providing configuration value for `initial_settings` at deployment, you can tweak a few
 WordPress settings. For detailed information on configurable parameters, please refer to the
-[reference guide](https://charmhub.io/wordpress-k8s/docs/reference).
+[reference guide](https://charmhub.io/wordpress-k8s/docs/reference-configurations).
 
 ```
 WORDPRESS_SETTINGS=$(cat << EOF

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Wordpress Documentation Overview
+
+WordPress is software designed for everyone, emphasizing accessibility, performance, security, and ease of use. The basic WordPress software is simple and predictable so you can easily get started. It also offers powerful features for growth and success.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,20 @@
-# Wordpress Documentation Overview
+# WordPress Operator
 
-WordPress is software designed for everyone, emphasizing accessibility, performance, security, and ease of use. The basic WordPress software is simple and predictable so you can easily get started. It also offers powerful features for growth and success.
+A Juju charm deploying and managing WordPress on Kubernetes. [WordPress](https://wordpress.com/) is the world's most popular website builder, and it's free and open-source.
+
+This charm simplifies initial deployment and "day N" operations of WordPress on Kubernetes, including scaling the number of instances, integration with SSO, access to OpenStack Swift object storage for redundant file storage and more. It allows for deployment on many different Kubernetes platforms, from [MicroK8s](https://microk8s.io/) to [Charmed Kubernetes](https://ubuntu.com/kubernetes) to public cloud Kubernetes offerings.
+
+As such, the charm makes it easy for those looking to take control of their own content management system whilst keeping operations simple, and gives them the freedom to deploy on the Kubernetes platform of their choice.
+
+For DevOps or SRE teams this charm will make operating WordPress simple and straightforward through Juju's clean interface. It will allow easy deployment into multiple environments for testing of changes, and supports scaling out for enterprise deployments.
+
+## Project and community
+
+The WordPress Operator is a member of the Ubuntu family. It's an open source project that warmly welcomes community projects, contributions, suggestions, fixes and constructive feedback.
+
+- [Code of conduct](https://ubuntu.com/community/code-of-conduct)
+- [Get support](https://discourse.charmhub.io/)
+- [Join our online chat](https://chat.charmhub.io/charmhub/channels/charm-dev)
+- [Contribute](Contribute)
+
+Thinking about using the WordPress Operator for your next project? [Get in touch](https://chat.charmhub.io/charmhub/channels/charm-dev)!

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -1,3 +1,3 @@
 # Actions
 
-See [Actions](https://charmhub.io/wordpress-k8s/actions?channel=edge).
+See [Actions](https://charmhub.io/wordpress-k8s/actions).

--- a/docs/reference/configurations.md
+++ b/docs/reference/configurations.md
@@ -1,3 +1,3 @@
 # Configurations
 
-See [Configure](https://charmhub.io/wordpress-k8s/configure?channel=edge).
+See [Configure](https://charmhub.io/wordpress-k8s/configure).

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -3,15 +3,15 @@
 ### db
 
 _Interface_: mysql  
-_Supported charms_: [charmed-osm-mariadb-k8s](https://charmhub.io/mysql),
+_Supported charms_: [charmed-osm-mariadb-k8s](https://charmhub.io/charmed-osm-mariadb-k8s),
 [mysql-k8s](https://charmhub.io/mysql-k8s)
 
 Database integration is a required relation for the wordpress-k8s charm to supply structured data
 storage for WordPress. It is recommended to use a juju native integration that provides a mysql
 interface by providing `mysql-interface-user` and `mysql-interface-database` parameters to
 wordpress-k8s charm configurations. See
-[configuration](https://charmhub.io/wordpress-k8s/configure?channel=edge) for more detail.
-Another way to establish database relation is to supply db_host, db_name, db_user, db_password
+[configuration](https://charmhub.io/wordpress-k8s/configure) for more detail.
+Another way to establish database relation is to supply `db_host`, `db_name`, `db_user`, `db_password`
 configuration parameters to the charm with a MySQL database. See Configuration section for detailed
 information regarding each of the parameters.
 
@@ -22,7 +22,7 @@ _Supported charms_: [nginx-ingress-integrator](https://charmhub.io/nginx-ingress
 
 Ingress manages external http/https access to services in a kubernetes cluster.
 Ingress relation through [nginx-ingress-integrator](https://charmhub.io/nginx-ingress-integrator)
-charm enables additional blog_hostname and use_nginx_ingress_modesec configurations. Note that the
+charm enables additional `blog_hostname` and `use_nginx_ingress_modesec` configurations. Note that the
 kubernetes cluster must already have an nginx ingress controller already deployed. Documentation to
 enable ingress in microk8s can be found [here](https://microk8s.io/docs/addon-ingress).
 
@@ -33,9 +33,9 @@ Example ingress relate command: `juju relate wordpress-k8s nginx-ingress-integra
 _Interface_: [prometheus_scrape](https://charmhub.io/interfaces/prometheus_scrape-v0)  
 _Supported charms_: [prometheus-k8s](https://charmhub.io/prometheus-k8s)
 
-Metrics-endpoint relation allows scraping the /metrics endpoint provided by apache-exporter sidecar
-on port 9117, which provides apache metrics from apache’s /server-status route. This internal
-apache’s /server-status route is not exposed and can only be accessed from within the same
+Metrics-endpoint relation allows scraping the `/metrics` endpoint provided by apache-exporter sidecar
+on port 9117, which provides apache metrics from apache’s `/server-status` route. This internal
+apache’s `/server-status` route is not exposed and can only be accessed from within the same
 Kubernetes pod. The metrics are exposed in the [open metrics format](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#data-model) and will only be scraped by Prometheus once the relation becomes active. For more
 information about the metrics exposed, please refer to the apache-exporter [documentation](https://github.com/Lusitaniae/apache_exporter#collectors).
 
@@ -46,8 +46,8 @@ Metrics-endpoint relate command: `juju relate wordpress-k8s prometheus-k8s`
 _Interface_: loki_push_api  
 _Supported charms_: [loki-k8s](https://charmhub.io/loki-k8s)
 
-Logging relation through the loki_push_api interface installs and runs promtail which ships the
-contents of local logs found at /var/log/apache2/access.log and /var/log/apache2/error.log to Loki.
+Logging relation through the `loki_push_api` interface installs and runs promtail which ships the
+contents of local logs found at `/var/log/apache2/access.log` and `/var/log/apache2/error.log` to Loki.
 This can then be queried through the loki api or easily visualized through Grafana.
 
 Logging-endpoint relate command: `juju relate wordpress-k8s loki-k8s`
@@ -59,8 +59,8 @@ _Supported charms_: [grafana-k8s](https://charmhub.io/grafana-k8s)
 
 Grafana-dashboard relation enables quick dashboard access already tailored to fit the needs of
 operators to monitor the charm. The template for the Grafana dashboard for wordpress-k8s charm can
-be found at /src/grafana_dashboards/wordpress.json. In Grafana UI, it can be found as “WordPress
-Operator Overview” under the General section of the dashboard browser(/dashboards). Modifications
+be found at `/src/grafana_dashboards/wordpress.json`. In Grafana UI, it can be found as “WordPress
+Operator Overview” under the General section of the dashboard browser(`/dashboards`). Modifications
 to the dashboard can be made but will not be persisted upon restart/redeployment of the charm.
 
 Grafana-Prometheus relate command: `juju relate grafana-k8s:grafana-source prometheus-k8s:grafana-source`  

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -60,7 +60,7 @@ _Supported charms_: [grafana-k8s](https://charmhub.io/grafana-k8s)
 Grafana-dashboard relation enables quick dashboard access already tailored to fit the needs of
 operators to monitor the charm. The template for the Grafana dashboard for wordpress-k8s charm can
 be found at `/src/grafana_dashboards/wordpress.json`. In Grafana UI, it can be found as “WordPress
-Operator Overview” under the General section of the dashboard browser(`/dashboards`). Modifications
+Operator Overview” under the General section of the dashboard browser (`/dashboards`). Modifications
 to the dashboard can be made but will not be persisted upon restart/redeployment of the charm.
 
 Grafana-Prometheus relate command: `juju relate grafana-k8s:grafana-source prometheus-k8s:grafana-source`  

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -2,11 +2,11 @@
 
 By default, the following WordPress plugins are installed with the latest version during the OCI
 image build time. If the plugins are installed during runtime with
-`juju config wordpress-k8s plugins=...`, the plugin will also be installed to it's latest version
-by default and may cause version differences between pods.
-Due to the clustered nature of the WordPress charm, installing plugins through UI has been disabled
-and can only be installed through the plugins configuration. Please see
-[Configurations](https://charmhub.io/wordpress-k8s/configure?channel=edge) section for more
+`juju config wordpress-k8s plugins=<plugin-slug>`, the plugin will also be installed to it's latest
+version by default and may cause version differences between pods.
+The wordpress-k8s charm supports multi-unit deployments. Therefore, installing plugins through UI
+has been disabled and can only be installed through the plugins configuration. Please see
+[Configurations](https://charmhub.io/wordpress-k8s/configure) section for more
 information.
 
 _\*The descriptions of the following plugins are taken from the WordPress plugin pages._
@@ -21,7 +21,7 @@ _\*The descriptions of the following plugins are taken from the WordPress plugin
   calendar with remote synchronization service.
 - [elementor](https://wordpress.org/plugins/elementor/): Intuitive visual website builder platform
   for WordPress.
-- [essential-addons-for-elementor-lite](https://wordpress.org/plugins/essential-addonselementor-lite/):
+- [essential-addons-for-elementor-lite](https://wordpress.org/plugins/essential-addons-for-elementor-lite/):
   Addons for website builder Elementor.
 - [favicon-by-realfavicongenerator](https://wordpress.org/plugins/favicon-by-realfavicongenerator/):
   Favicon generator for desktop browsers, iPhone/iPad, Android devices, Windows 8 tablets and more.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,4 +1,4 @@
-# Tutorial
+# Getting Started
 
 ## What you'll learn
 
@@ -48,8 +48,9 @@ interface.
 
 ```
 juju deploy mysql-k8s \
-    --config mysql-interface-user=wordpress-tutorial-user \
-    --config mysql-interface-database=wordpress-tutorial-database
+  --config mysql-interface-user=wordpress-tutorial-user \
+  --config mysql-interface-database=wordpress-tutorial-database
+
 # mysql interface is required since mysql-k8s charm provides multiple mysql interfaces
 juju relate wordpress-k8s:mysql mysql-k8s:mysql
 ```
@@ -65,11 +66,13 @@ and should not be used for production environments.
 
 ```
 microk8s kubectl run mysql -n wordpress-tutorial --image=mysql:latest \
---env="MYSQL_ROOT_PASSWORD=<strong-password>" \
---env=”MYSQL_DATABASE=wordpress-tutorial-database” \
---env=”MYSQL_USER=wordpress-tutorial-user” \
---env=”MYSQL_PASSWORD=<strong-password>
+  --env="MYSQL_ROOT_PASSWORD=<strong-password>" \
+  --env=”MYSQL_DATABASE=wordpress-tutorial-database” \
+  --env=”MYSQL_USER=wordpress-tutorial-user” \
+  --env=”MYSQL_PASSWORD=<strong-password>
+
 WORDPRESS_IP=microk8s kubectl get pod mysql --template '{{.status.podIP}}'
+
 juju config wordpress-k8s \
 db_host=$WORDPRESS_IP \
 db_name=wordpress-tutorial-database \
@@ -107,9 +110,9 @@ unit-wordpress-k8s-0:
     password: <password> # should look something like: XXXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXX
   status: completed
   timing:
-    completed: 2023-02-24 02:46:27 +0000 UTC
-    enqueued: 2023-02-24 02:46:25 +0000 UTC
-    started: 2023-02-24 02:46:26 +0000 UTC
+    completed: <timestamp>
+    enqueued: <timestamp>
+    started: <timestamp>
 ```
 
 You can now access your WordPress application at `http://<UNIT_IP>/wp-login.php` and login with

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
 [testenv:static]
 description = Run static analysis tests
 deps =
-    bandit
+    bandit[toml]
     toml
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
This PR changes the documentation reference from `edge` channel to `stable`.
Furthermore, additional formatting inconsistencies(code formatting, timestamps, reference to wordpress-k8s charm rather than WordPress) are improved and index file(overview documentation) has been added.
