### PR TITLE
fix: upgrade test timeout workaround

### DIFF
--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -232,7 +232,8 @@ async def build_and_upgrade_fixture(
     """
     assert ops_test.model
     charm = await ops_test.build_charm(".")
-    await ops_test.model.remove_application(application_name)
+    # Most of the times the integration tests will fail due to timeout without the force flag.
+    await ops_test.juju("remove-application", application_name, "--force")
 
     def wordpress_removed() -> bool:
         """Check if WordPress charm was fully removed.


### PR DESCRIPTION
This PR addresses the integration test failure in upgrade-tests due to a timeout error, caused by juju's flaky remove-application operation.
This blocks https://github.com/canonical/wordpress-k8s-operator/pull/55 and https://github.com/canonical/wordpress-k8s-operator/pull/58 and hence is a required workaround(some of theses tests have gone up to 10 attempts).
I've also tried the `block_until_done=True` which kept the test running indefinitely. 
