### PR TITLE
feat: display wp version in juju app version

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,7 +19,7 @@ from ops.pebble import Client
 
 from charm import WordpressCharm
 from exceptions import WordPressBlockedStatusException, WordPressWaitingStatusException
-from tests.unit.wordpress_mock import WordpressPatch
+from tests.unit.wordpress_mock import WordpressContainerMock, WordpressPatch
 
 
 def test_generate_wp_secret_keys(harness: ops.testing.Harness):
@@ -917,3 +917,16 @@ def test_mysql_connection_error(harness: ops.testing.Harness, setup_replica_cons
     harness.update_config(db_config)
     assert isinstance(harness.model.unit.status, ops.charm.model.BlockedStatus)
     assert harness.model.unit.status.message == "MySQL error 2003"
+
+
+@pytest.mark.usefixtures("attach_storage")
+def test_wordpress_version_set(harness: ops.testing.Harness):
+    """
+    arrange: no arrange.
+    act: charm container is ready.
+    assert: workload version is set.
+    """
+    harness.set_can_connect(harness.model.unit.containers["wordpress"], True)
+    harness.begin_with_initial_hooks()
+
+    assert harness.get_workload_version() == WordpressContainerMock._WORDPRESS_VERSION

--- a/tests/unit/wordpress_mock.py
+++ b/tests/unit/wordpress_mock.py
@@ -341,6 +341,7 @@ class WordpressContainerMock:
     """
 
     _exec_handler = HandlerRegistry()
+    _WORDPRESS_VERSION = "5.9.3"
 
     def __init__(
         self,
@@ -626,7 +627,7 @@ class WordpressContainerMock:
     @_exec_handler.register(lambda cmd: cmd[:3] == ["wp", "core", "version"])
     def _mock_wp_core_version(self, _cmd):
         """Simulate ``wp core version`` command execution in the container."""
-        return ExecProcessMock(return_code=0, stdout="5.9.3", stderr="")
+        return ExecProcessMock(return_code=0, stdout=self._WORDPRESS_VERSION, stderr="")
 
     def __getattr__(self, item):
         """Passthrough anything else to :class:`ops.charm.model.Container`.

--- a/tests/unit/wordpress_mock.py
+++ b/tests/unit/wordpress_mock.py
@@ -623,6 +623,11 @@ class WordpressContainerMock:
             pass
         return ExecProcessMock(return_code=0, stdout="", stderr="")
 
+    @_exec_handler.register(lambda cmd: cmd[:3] == ["wp", "core", "version"])
+    def _mock_wp_core_version(self, _cmd):
+        """Simulate ``wp core version`` command execution in the container."""
+        return ExecProcessMock(return_code=0, stdout="5.9.3", stderr="")
+
     def __getattr__(self, item):
         """Passthrough anything else to :class:`ops.charm.model.Container`.
 


### PR DESCRIPTION
This PR is to show the WordPress app version when deploying the wordpress-k8s charm.
<img width="421" alt="image" src="https://user-images.githubusercontent.com/37652070/228409789-8aaf8d95-ad38-4902-9367-6c8292eb52a9.png">
