### PR TITLE
Fix the charm compatibility issue on focal

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,8 +6,6 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "22.04"
-    - name: "ubuntu"
-      channel: "20.04"
 parts:
   charm:
     # Tell charmcraft to not use requirements.txt

--- a/src/types_.py
+++ b/src/types_.py
@@ -3,7 +3,7 @@
 
 """Module for commonly used internal types in WordPress charm."""
 
-from typing import Any, NamedTuple, Union
+from typing import Any, NamedTuple, Optional, Union
 
 
 class CommandExecResult(NamedTuple):
@@ -44,7 +44,7 @@ class DatabaseConfig(NamedTuple):
         password: The password to use to authenticat to the database.
     """
 
-    hostname: str | None
-    database: str | None
-    username: str | None
-    password: str | None
+    hostname: Optional[str]
+    database: Optional[str]
+    username: Optional[str]
+    password: Optional[str]


### PR DESCRIPTION
WordPress charm is not compatible with Python 3.8, the default Python installation on focal right now. 
Update the charm to drop support for `focal` series and change the syntax to be compatible with Python 3.8