### PR TITLE
fix: python 3.8 typing compatibility

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,7 @@ import string
 import textwrap
 import time
 import traceback
-from typing import Any, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import mysql.connector
 import ops.charm
@@ -294,7 +294,7 @@ class WordpressCharm(CharmBase):
             "nonce_salt",
         ]
 
-    def _generate_wp_secret_keys(self) -> dict[str, str]:
+    def _generate_wp_secret_keys(self) -> Dict[str, str]:
         """Generate random secure secrets for each secret required by WordPress.
 
         Returns:
@@ -599,7 +599,7 @@ class WordpressCharm(CharmBase):
         return self._run_wp_cli(["wp", "core", "is-installed"]).return_code == 0
 
     @property
-    def _config_database_config(self) -> types_.DatabaseConfig | None:
+    def _config_database_config(self) -> Optional[types_.DatabaseConfig]:
         """Database configuration details from charm config.
 
         Returns:
@@ -618,7 +618,7 @@ class WordpressCharm(CharmBase):
         return None
 
     @property
-    def _db_relation_database_config(self) -> types_.DatabaseConfig | None:
+    def _db_relation_database_config(self) -> Optional[types_.DatabaseConfig]:
         """Database configuration details from stored state.
 
         Since the legacy db relation is per-unit basis, the relation data must be stored in charm
@@ -638,7 +638,7 @@ class WordpressCharm(CharmBase):
             password=self.state.relation_db_password,
         )
 
-    def _parse_database_endpoints(self, endpoint: str | None) -> str | None:
+    def _parse_database_endpoints(self, endpoint: Optional[str]) -> Optional[str]:
         """Retrieve a single database endpoint.
 
         Args:
@@ -662,7 +662,7 @@ class WordpressCharm(CharmBase):
         return host_port[0]
 
     @property
-    def _database_relation_database_config(self) -> types_.DatabaseConfig | None:
+    def _database_relation_database_config(self) -> Optional[types_.DatabaseConfig]:
         """Database configuration details from database relation.
 
         Returns:
@@ -680,7 +680,7 @@ class WordpressCharm(CharmBase):
         )
 
     @property
-    def _current_effective_db_info(self) -> types_.DatabaseConfig | None:
+    def _current_effective_db_info(self) -> Optional[types_.DatabaseConfig]:
         """Get the current effective db connection information.
 
         The order of precedence for effective configurations are as follows:
@@ -1121,7 +1121,7 @@ class WordpressCharm(CharmBase):
         return types_.ExecResult(success=True, result=None, message="")
 
     def _activate_plugin(
-        self, plugin: str, options: dict[str, Union[str, dict]]
+        self, plugin: str, options: Dict[str, Union[str, dict]]
     ) -> types_.ExecResult:
         """Activate a WordPress plugin and set WordPress options after activation.
 
@@ -1323,7 +1323,7 @@ class WordpressCharm(CharmBase):
         self._run_cli(["a2disconf", conf_name])
         self._start_server()
 
-    def _swift_config(self) -> dict[str, Any]:
+    def _swift_config(self) -> Dict[str, Any]:
         """Load swift configuration from charm config.
 
         The legacy swift plugin options ``url`` or ``prefix`` will be converted to ``swift-url``
@@ -1387,7 +1387,7 @@ class WordpressCharm(CharmBase):
                 )
         return swift_config
 
-    def _config_swift_plugin(self, swift_config: dict[str, Any]) -> None:
+    def _config_swift_plugin(self, swift_config: Dict[str, Any]) -> None:
         """Activate or deactivate the swift plugin based on the swift config in the charm config.
 
         Args:

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,7 @@ import string
 import textwrap
 import time
 import traceback
-from typing import Any, Union
+from typing import Any, List, Union
 
 import mysql.connector
 import ops.charm
@@ -480,7 +480,7 @@ class WordpressCharm(CharmBase):
 
     def _run_cli(
         self,
-        cmd: list[str],
+        cmd: List[str],
         user: Union[str, None] = None,
         group: Union[str, None] = None,
         working_dir: Union[str, None] = None,
@@ -533,7 +533,7 @@ class WordpressCharm(CharmBase):
         return result
 
     def _run_wp_cli(
-        self, cmd: list[str], timeout: int = 60, combine_stderr: bool = False
+        self, cmd: List[str], timeout: int = 60, combine_stderr: bool = False
     ) -> types_.CommandExecResult:
         """Execute a wp-cli command, this is a wrapper of :meth:`charm.WordpressCharm._run_cli`.
 
@@ -560,7 +560,7 @@ class WordpressCharm(CharmBase):
         return result
 
     def _wrapped_run_wp_cli(
-        self, cmd: list[str], timeout: int = 60, error_message: Union[str, None] = None
+        self, cmd: List[str], timeout: int = 60, error_message: Union[str, None] = None
     ) -> types_.ExecResult:
         """Run wp cli command and return the result as ``types_.ExecResult``.
 
@@ -1152,7 +1152,7 @@ class WordpressCharm(CharmBase):
                 )
         return types_.ExecResult(success=True, result=None, message="")
 
-    def _deactivate_plugin(self, plugin: str, options: list[str]) -> types_.ExecResult:
+    def _deactivate_plugin(self, plugin: str, options: List[str]) -> types_.ExecResult:
         """Deactivate a WordPress plugin and delete WordPress options after deactivation.
 
         Args:

--- a/src/cos.py
+++ b/src/cos.py
@@ -4,7 +4,7 @@
 # See LICENSE file for licensing details.
 
 """COS integration for WordPress charm."""
-from typing import TypedDict
+from typing import Dict, List, TypedDict
 
 from ops.pebble import Check, Layer, Service
 
@@ -20,8 +20,8 @@ class PrometheusStaticConfig(TypedDict, total=False):
         labels: labels assigned to all metrics scraped from the targets.
     """
 
-    targets: list[str]
-    labels: dict[str, str]
+    targets: List[str]
+    labels: Dict[str, str]
 
 
 class PrometheusMetricsJob(TypedDict, total=False):
@@ -36,7 +36,7 @@ class PrometheusMetricsJob(TypedDict, total=False):
     """
 
     metrics_path: str
-    static_configs: list[PrometheusStaticConfig]
+    static_configs: List[PrometheusStaticConfig]
 
 
 APACHE_PROMETHEUS_SCRAPE_PORT = "9117"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,7 @@ import logging
 import pathlib
 import re
 import typing
+from typing import Dict, List, Optional
 
 import kubernetes
 import pytest
@@ -130,7 +131,7 @@ async def get_app_revision(ops_test: OpsTest) -> typing.Callable[[str], typing.A
 
 
 @pytest_asyncio.fixture(scope="function", name="unit_ip_list")
-async def fixture_unit_ip_list(get_unit_ip_list: typing.Callable[[], typing.Awaitable[list[str]]]):
+async def fixture_unit_ip_list(get_unit_ip_list: typing.Callable[[], typing.Awaitable[List[str]]]):
     """A fixture containing ip addresses of current units.
 
     Yields:
@@ -439,7 +440,7 @@ async def build_and_deploy_fixture(
 @pytest_asyncio.fixture(scope="module", name="mysql")
 async def mysql_fixture(model: Model):
     """Deploy mysql-k8s application fixture."""
-    mysql = await model.deploy("mysql-k8s", channel="edge", trust=True)
+    mysql = await model.deploy("mysql-k8s", channel="8.0/stable", trust=True)
     return mysql
 
 
@@ -489,7 +490,7 @@ def image_fixture() -> bytes:
 
 
 @pytest.fixture(scope="module", name="swift_conn")
-def swift_conn_fixture(openstack_environment) -> swiftclient.Connection | None:
+def swift_conn_fixture(openstack_environment) -> Optional[swiftclient.Connection]:
     """Create a swift connection client."""
     if openstack_environment is None:
         return None
@@ -511,8 +512,8 @@ def swift_conn_fixture(openstack_environment) -> swiftclient.Connection | None:
 def swift_config_fixture(
     request: pytest.FixtureRequest,
     swift_conn: swiftclient.Connection,
-    openstack_environment: typing.Optional[typing.Dict[str, str]],
-) -> typing.Optional[typing.Dict[str, str]]:
+    openstack_environment: Optional[Dict[str, str]],
+) -> Optional[Dict[str, str]]:
     """Create a swift config dict that can be used for wp_plugin_openstack-objectstorage_config."""
     if openstack_environment is None:
         return None

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -9,7 +9,6 @@ import io
 import json
 import secrets
 import socket
-import typing
 import unittest.mock
 import urllib.parse
 from typing import Callable, List, Set

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -12,7 +12,7 @@ import socket
 import typing
 import unittest.mock
 import urllib.parse
-from typing import Callable
+from typing import Callable, List, Set
 
 import PIL.Image
 import pytest
@@ -237,15 +237,15 @@ async def test_wordpress_default_themes(unit_ip_list, get_theme_list_from_ip):
 async def test_wordpress_install_uninstall_themes(
     model: Model,
     application_name: str,
-    unit_ip_list: list[str],
-    get_theme_list_from_ip: Callable[[str], list[str]],
+    unit_ip_list: List[str],
+    get_theme_list_from_ip: Callable[[str], List[str]],
 ):
     """
     arrange: after WordPress charm has been deployed and db relation established.
     act: change themes setting in config.
     assert: themes should be installed and uninstalled accordingly.
     """
-    theme_change_list: typing.List[typing.Set[str]] = [
+    theme_change_list: List[Set[str]] = [
         {"twentyfifteen", "classic"},
         {"tt1-blocks", "twentyfifteen"},
         {"tt1-blocks"},
@@ -300,15 +300,15 @@ async def test_wordpress_theme_installation_error(model: Model, application_name
 async def test_wordpress_install_uninstall_plugins(
     model: Model,
     application_name: str,
-    unit_ip_list: list[str],
-    get_plugin_list_from_ip: Callable[[str], list[str]],
+    unit_ip_list: List[str],
+    get_plugin_list_from_ip: Callable[[str], List[str]],
 ):
     """
     arrange: after WordPress charm has been deployed and db relation established.
     act: change plugins setting in config.
     assert: plugins should be installed and uninstalled accordingly.
     """
-    plugin_change_list: typing.List[typing.Set[str]] = [
+    plugin_change_list: List[Set[str]] = [
         {"classic-editor", "classic-widgets"},
         {"classic-editor"},
         {"classic-widgets"},
@@ -543,7 +543,7 @@ async def test_prometheus_integration(
     model: Model,
     prometheus: Application,
     application_name: str,
-    unit_ip_list: list[str],
+    unit_ip_list: List[str],
 ):
     """
     arrange: after WordPress charm has been deployed and relations established with prometheus.


### PR DESCRIPTION
This PR fixes the type hints that are not compatible with Python 3.8.

