### PR TITLE
Extend the database probe timeout

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -135,7 +135,7 @@ class WordpressCharm(CharmBase):
     ]
 
     _DB_CHECK_INTERVAL = 1
-    _DB_CHECK_TIMEOUT = 60
+    _DB_CHECK_TIMEOUT = 300
 
     state = StoredState()
 

--- a/tests/integration/test_error.py
+++ b/tests/integration/test_error.py
@@ -32,12 +32,12 @@ async def test_incorrect_db_config(ops_test: pytest_operator.plugin.OpsTest, app
     assert: charm should be blocked by WordPress installation errors, instead of lacking
         of database connection info.
     """
-    # Database configuration can retry for up to 60 seconds before giving up and showing an error.
+    # Database configuration can retry for up to 300 seconds before giving up and showing an error.
     # Default wait_for_idle 15 seconds in ``app_config`` fixture is too short for incorrect
     # db config.
     assert ops_test.model
     await ops_test.model.wait_for_idle(
-        idle_period=60, status=BLOCKED_STATUS_NAME, apps=[application_name]
+        idle_period=360, status=BLOCKED_STATUS_NAME, apps=[application_name]
     )
 
     for unit in ops_test.model.applications[application_name].units:

--- a/tests/integration/test_error.py
+++ b/tests/integration/test_error.py
@@ -37,7 +37,7 @@ async def test_incorrect_db_config(ops_test: pytest_operator.plugin.OpsTest, app
     # db config.
     assert ops_test.model
     await ops_test.model.wait_for_idle(
-        idle_period=360, status=BLOCKED_STATUS_NAME, apps=[application_name]
+        idle_period=360, status=BLOCKED_STATUS_NAME, apps=[application_name], timeout=1200
     )
 
     for unit in ops_test.model.applications[application_name].units:


### PR DESCRIPTION
Currently, WordPress will retry connecting to the database for 1 minute after the database connection info is provided through the database relation. However, this 1-minute timeout is too short for certain database charms. In this commit, we extend the database probe timeout from 1 minute to 5 minutes.