### PR TITLE
fix: use edge version of loki-k8s to stabilise integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -62,5 +62,8 @@ jobs:
     needs:
       - integration-tests
       - integration-tests-with-secrets
+    if: always()
     steps:
-      - run: echo required checks passed
+      - run: |
+          [ '${{ needs.integration-tests-with-secrets.result }}' = 'success' ] || (echo integration-test-with-secrets failed && false)
+          [ '${{ needs.integration-test.result }}' = 'success' ] || (echo integration-test failed && false)

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -66,4 +66,4 @@ jobs:
     steps:
       - run: |
           [ '${{ needs.integration-tests-with-secrets.result }}' = 'success' ] || (echo integration-test-with-secrets failed && false)
-          [ '${{ needs.integration-test.result }}' = 'success' ] || (echo integration-test failed && false)
+          [ '${{ needs.integration-tests.result }}' = 'success' ] || (echo integration-test failed && false)

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -52,7 +52,7 @@ jobs:
       registry: ghcr.io
       runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
       pre-run-script: |
-        -c "sudo microk8s enable registry hostpath-storage
+        -c "sudo microk8s enable hostpath-storage
           sudo microk8s kubectl -n kube-system rollout status -w deployment/hostpath-provisioner
           sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config"
       setup-devstack-swift: true

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -343,7 +343,9 @@ import tempfile
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
+from urllib.request import urlopen
 
 import yaml
 from charms.observability_libs.v0.juju_topology import JujuTopology
@@ -368,7 +370,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 33
+LIBPATCH = 35
 
 logger = logging.getLogger(__name__)
 
@@ -2222,6 +2224,8 @@ class MetricsEndpointAggregator(Object):
                         "juju_application": application_name,
                         "juju_unit": unit_name,
                         "host": target["hostname"],
+                        # Expanding this will merge the dicts and replace the
+                        # topology labels if any were present/found
                         **self._static_config_extra_labels(target),
                     },
                 }
@@ -2244,7 +2248,16 @@ class MetricsEndpointAggregator(Object):
                 logger.debug("Could not perform DNS lookup for %s", target["hostname"])
                 dns_name = target["hostname"]
             extra_info["dns_name"] = dns_name
+        label_re = re.compile(r'(?P<label>juju.*?)="(?P<value>.*?)",?')
 
+        try:
+            with urlopen(f'http://{target["hostname"]}:{target["port"]}/metrics') as resp:
+                data = resp.read().decode("utf-8").splitlines()
+                for metric in data:
+                    for match in label_re.finditer(metric):
+                        extra_info[match.group("label")] = match.group("value")
+        except (HTTPError, URLError, OSError, ConnectionResetError, Exception) as e:
+            logger.debug("Could not scrape target: %s", e)
         return extra_info
 
     @property

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -464,7 +464,7 @@ async def loki_fixture(
     model: Model, application_name: str
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy and return loki charm application with relation to WordPress charm."""
-    loki = await model.deploy("loki-k8s", channel="stable", trust=True)
+    loki = await model.deploy("loki-k8s", channel="edge", trust=True)
     await loki.relate(LOKI_RELATION_NAME, f"{application_name}:{LOKI_RELATION_NAME}")
     yield loki
     await loki.remove_relation(LOKI_RELATION_NAME, f"{application_name}:{LOKI_RELATION_NAME}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -421,18 +421,7 @@ async def build_and_deploy_fixture(
         build_and_deploy_wordpress(),
         deploy_and_wait_for_mysql_pod(),
         model.deploy("charmed-osm-mariadb-k8s", application_name="mariadb"),
-        # temporary fix for the CharmHub problem
-        ops_test.juju(
-            "deploy",
-            "nginx-ingress-integrator",
-            "ingress",
-            "--channel",
-            "edge",
-            "--series",
-            "focal",
-            "--trust",
-            check=True,
-        ),
+        model.deploy("nginx-ingress-integrator", series="focal", trust=True),
     )
     await model.wait_for_idle()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -449,7 +449,7 @@ async def prometheus_fixture(
     model: Model, application_name: str
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy and yield prometheus charm application with relation to WordPress charm."""
-    prometheus = await model.deploy("prometheus-k8s", channel="stable", trust=True)
+    prometheus = await model.deploy("prometheus-k8s", channel="latest/edge", trust=True)
     await prometheus.relate(
         PROMETHEUS_RELATION_NAME, f"{application_name}:{PROMETHEUS_RELATION_NAME}"
     )
@@ -478,7 +478,7 @@ async def grafana_fixture(
     model: Model, application_name: str
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy and return grafana charm application with relation to WordPress charm."""
-    grafana = await model.deploy("grafana-k8s", channel="stable", trust=True)
+    grafana = await model.deploy("grafana-k8s", channel="latest/edge", trust=True)
     await grafana.relate(GRAFANA_RELATION_NAME, f"{application_name}:{GRAFANA_RELATION_NAME}")
     yield grafana
     await grafana.remove_relation(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -464,7 +464,10 @@ async def loki_fixture(
     model: Model, application_name: str
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy and return loki charm application with relation to WordPress charm."""
-    loki = await model.deploy("loki-k8s", channel="edge", trust=True)
+    # 2023-04-18 The Loki stable is missing container.can_connect guard and hence fails the tests
+    # often. Resort to using the latest edge (revision 82) until it is promoted to stable.
+    # https://chat.charmhub.io/charmhub/pl/xgqyman4btym3ff74fcjomzxbw
+    loki = await model.deploy("loki-k8s", channel="latest/edge", trust=True)
     await loki.relate(LOKI_RELATION_NAME, f"{application_name}:{LOKI_RELATION_NAME}")
     yield loki
     await loki.remove_relation(LOKI_RELATION_NAME, f"{application_name}:{LOKI_RELATION_NAME}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -458,8 +458,8 @@ async def loki_fixture(
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy and return loki charm application with relation to WordPress charm."""
     # 2023-04-18 The Loki stable is missing container.can_connect guard and hence fails the tests
-    # often. Resort to using the latest edge (revision 82) until it is promoted to stable (revision 60).
-    # https://chat.charmhub.io/charmhub/pl/xgqyman4btym3ff74fcjomzxbw
+    # often. Resort to using the latest edge (revision 82) until it is promoted to stable
+    # (revision 60). See https://chat.charmhub.io/charmhub/pl/xgqyman4btym3ff74fcjomzxbw
     loki = await model.deploy("loki-k8s", channel="latest/edge", trust=True)
     await loki.relate(LOKI_RELATION_NAME, f"{application_name}:{LOKI_RELATION_NAME}")
     yield loki

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -440,6 +440,8 @@ async def prometheus_fixture(
     model: Model, application_name: str
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy and yield prometheus charm application with relation to WordPress charm."""
+    # 2023-04-18 Temporarily use edge until revision discrepancy is resolved.
+    # edge revision: 123, stable revision: 103
     prometheus = await model.deploy("prometheus-k8s", channel="latest/edge", trust=True)
     await prometheus.relate(
         PROMETHEUS_RELATION_NAME, f"{application_name}:{PROMETHEUS_RELATION_NAME}"
@@ -456,7 +458,7 @@ async def loki_fixture(
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy and return loki charm application with relation to WordPress charm."""
     # 2023-04-18 The Loki stable is missing container.can_connect guard and hence fails the tests
-    # often. Resort to using the latest edge (revision 82) until it is promoted to stable.
+    # often. Resort to using the latest edge (revision 82) until it is promoted to stable (revision 60).
     # https://chat.charmhub.io/charmhub/pl/xgqyman4btym3ff74fcjomzxbw
     loki = await model.deploy("loki-k8s", channel="latest/edge", trust=True)
     await loki.relate(LOKI_RELATION_NAME, f"{application_name}:{LOKI_RELATION_NAME}")
@@ -469,6 +471,8 @@ async def grafana_fixture(
     model: Model, application_name: str
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy and return grafana charm application with relation to WordPress charm."""
+    # 2023-04-18 Temporarily use edge until revision discrepancy is resolved.
+    # edge revision: 78, stable revision: 64
     grafana = await model.deploy("grafana-k8s", channel="latest/edge", trust=True)
     await grafana.relate(GRAFANA_RELATION_NAME, f"{application_name}:{GRAFANA_RELATION_NAME}")
     yield grafana

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -421,7 +421,9 @@ async def build_and_deploy_fixture(
         build_and_deploy_wordpress(),
         deploy_and_wait_for_mysql_pod(),
         model.deploy("charmed-osm-mariadb-k8s", application_name="mariadb"),
-        model.deploy("nginx-ingress-integrator", series="focal", trust=True),
+        model.deploy(
+            "nginx-ingress-integrator", series="focal", trust=True, application_name="ingress"
+        ),
     )
     await model.wait_for_idle()
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,37 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helpers for WordPress charm integration tests."""
+
+import asyncio
+
+from juju.client._definitions import FullStatus
+from juju.model import Model
+
+
+async def wait_unit_agents_idle(model: Model, application_name: str):
+    """Wait for application unit agents to be in idle state.
+
+    This function is used for applications status that stays in idle state while the unit agent
+    states could be in executing. Accessing any of the application while the units are executing
+    may lead to an incorrect state being returned, hence the wait_unit_agents_idle.
+
+    Raises:
+        TimeoutError: if application units do not become idle within given time.
+    """
+    idle = False
+    for _ in range(5):
+        status: FullStatus = await model.get_status(filters=[application_name])
+        (
+            print(f"{application_name} unit status: ", unit.agent_status.status)
+            for unit in status.applications[application_name].units.values()
+        )
+        idle = all(
+            unit.agent_status.status == "idle"
+            for unit in status.applications[application_name].units.values()
+        )
+        if idle:
+            break
+        await asyncio.sleep(10.0)
+    if not idle:
+        raise TimeoutError(f"{application_name} unit agent state not idle.")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -16,16 +16,16 @@ async def wait_unit_agents_idle(model: Model, application_name: str):
     states could be in executing. Accessing any of the application while the units are executing
     may lead to an incorrect state being returned, hence the wait_unit_agents_idle.
 
+    Args:
+        model: The model in test.
+        application_name: The name of the application to wait for units to become idle.
+
     Raises:
         TimeoutError: if application units do not become idle within given time.
     """
     idle = False
     for _ in range(5):
         status: FullStatus = await model.get_status(filters=[application_name])
-        (
-            print(f"{application_name} unit status: ", unit.agent_status.status)
-            for unit in status.applications[application_name].units.values()
-        )
         idle = all(
             unit.agent_status.status == "idle"
             for unit in status.applications[application_name].units.values()

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -579,7 +579,11 @@ async def test_loki_integration(
     """
 
     async def wait_loki_unit_agent_idle():
-        """Wait for loki unit agent to be in idle state."""
+        """Wait for loki unit agent to be in idle state.
+
+        Raises:
+            TimeoutError if loki does not become idle within given time.
+        """
         idle = False
         for _ in range(3):
             status: FullStatus = await model.get_status(filters=[loki.name])

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -577,29 +577,8 @@ async def test_loki_integration(
     assert: loki joins relation successfully, logs are being output to container and to files for
         loki to scrape.
     """
-
-    async def wait_loki_unit_agent_idle():
-        """Wait for loki unit agent to be in idle state.
-
-        Raises:
-            TimeoutError: if loki does not become idle within given time.
-        """
-        idle = False
-        for _ in range(3):
-            status: FullStatus = await model.get_status(filters=[loki.name])
-            for unit in status.applications[loki.name].units.values():
-                if unit.agent_status.status == "idle":
-                    idle = True
-                    break
-            if idle:
-                break
-            await asyncio.sleep(10.0)
-        if not idle:
-            raise TimeoutError("Loki unit agent state not idle.")
-
     await model.wait_for_idle(apps=[application_name, loki.name], status="active", idle_period=60)
 
-    await wait_loki_unit_agent_idle()
     status: FullStatus = await model.get_status(filters=[loki.name])
     for unit in status.applications[loki.name].units.values():
         series = requests.get(f"http://{unit.address}:3100/loki/api/v1/series", timeout=10).json()

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -582,7 +582,7 @@ async def test_loki_integration(
         """Wait for loki unit agent to be in idle state.
 
         Raises:
-            TimeoutError if loki does not become idle within given time.
+            TimeoutError: if loki does not become idle within given time.
         """
         idle = False
         for _ in range(3):
@@ -634,7 +634,9 @@ async def test_grafana_integration(
     await prometheus.relate("grafana-source", f"{grafana.name}:grafana-source")
     await loki.relate("grafana-source", f"{grafana.name}:grafana-source")
     await model.wait_for_idle(
-        apps=[application_name, prometheus.name, loki.name, grafana.name], status="active"
+        apps=[application_name, prometheus.name, loki.name, grafana.name],
+        status="active",
+        idle_period=60,
     )
 
     action: Action = await grafana.units[0].run_action("get-admin-password")

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -5,6 +5,7 @@
 
 """Integration tests for WordPress charm."""
 
+import asyncio
 import io
 import json
 import secrets
@@ -576,7 +577,29 @@ async def test_loki_integration(
     assert: loki joins relation successfully, logs are being output to container and to files for
         loki to scrape.
     """
+
+    async def wait_loki_unit_agent_idle():
+        """Wait for loki unit agent to be in idle state.
+
+        Raises:
+            TimeoutError: if loki does not become idle within given time.
+        """
+        idle = False
+        for _ in range(3):
+            status: FullStatus = await model.get_status(filters=[loki.name])
+            for unit in status.applications[loki.name].units.values():
+                if unit.agent_status.status == "idle":
+                    idle = True
+                    break
+            if idle:
+                break
+            await asyncio.sleep(10.0)
+        if not idle:
+            raise TimeoutError("Loki unit agent state not idle.")
+
     await model.wait_for_idle(apps=[application_name, loki.name], status="active", idle_period=60)
+
+    await wait_loki_unit_agent_idle()
 
     status: FullStatus = await model.get_status(filters=[loki.name])
     for unit in status.applications[loki.name].units.values():

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -602,7 +602,6 @@ async def test_loki_integration(
     await wait_loki_unit_agent_idle()
     status: FullStatus = await model.get_status(filters=[loki.name])
     for unit in status.applications[loki.name].units.values():
-        unit.agent_status.status
         series = requests.get(f"http://{unit.address}:3100/loki/api/v1/series", timeout=10).json()
         log_files = set(series_data["filename"] for series_data in series["data"])
         assert "/var/log/apache2/error.log" in log_files

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -5,7 +5,6 @@
 
 """Integration tests for WordPress charm."""
 
-import asyncio
 import io
 import json
 import secrets

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -593,7 +593,7 @@ async def test_loki_integration(
         if not idle:
             raise TimeoutError("Loki unit agent state not idle.")
 
-    await model.wait_for_idle(apps=[application_name, loki.name], status="active", idle_period=30)
+    await model.wait_for_idle(apps=[application_name, loki.name], status="active", idle_period=60)
 
     await wait_loki_unit_agent_idle()
     status: FullStatus = await model.get_status(filters=[loki.name])

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -576,7 +576,7 @@ async def test_loki_integration(
     assert: loki joins relation successfully, logs are being output to container and to files for
         loki to scrape.
     """
-    await model.wait_for_idle(apps=[application_name, loki.name], status="active")
+    await model.wait_for_idle(apps=[application_name, loki.name], status="active", idle_period=30)
 
     status: FullStatus = await model.get_status(filters=[loki.name])
     for unit in status.applications[loki.name].units.values():

--- a/tests/integration/test_podspec_upgrade.py
+++ b/tests/integration/test_podspec_upgrade.py
@@ -13,6 +13,7 @@ import logging
 import re
 import subprocess  # nosec
 import time
+import typing
 from pathlib import Path
 
 import kubernetes
@@ -159,7 +160,7 @@ async def create_example_blog_fixture(
 
     wordpress_pod = get_wordpress_podspec_pod()
 
-    def kubernetes_exec(cmd: list[str]):
+    def kubernetes_exec(cmd: typing.List[str]):
         """Execute a command in WordPress pod.
 
         Args:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -88,7 +88,7 @@ def example_database_host_port_fixture():
 
 
 @pytest.fixture(scope="function", name="example_database_info")
-def example_database_info_fixture(example_database_host_port: tuple[str, str]):
+def example_database_info_fixture(example_database_host_port: typing.Tuple[str, str]):
     """An example database connection info from mysql_client interface."""
     return {
         "endpoints": ":".join(example_database_host_port),
@@ -110,7 +110,7 @@ def example_invalid_database_info_fixture():
 
 
 @pytest.fixture(scope="function")
-def setup_db_relation(harness: ops.testing.Harness, example_db_info: dict[str, str]):
+def setup_db_relation(harness: ops.testing.Harness, example_db_info: typing.Dict[str, str]):
     """Yields a function that can be used to set up db relation.
 
     After calling the yielded function, a db relation will be set up. example_db_info will be used
@@ -132,7 +132,9 @@ def setup_db_relation(harness: ops.testing.Harness, example_db_info: dict[str, s
 
 
 @pytest.fixture(scope="function")
-def setup_database_relation(harness: ops.testing.Harness, example_database_info: dict[str, str]):
+def setup_database_relation(
+    harness: ops.testing.Harness, example_database_info: typing.Dict[str, str]
+):
     """Yields a function that can be used to set up database relation.
 
     After calling the yielded function, a database relation will be set up. example_database_info
@@ -155,7 +157,7 @@ def setup_database_relation(harness: ops.testing.Harness, example_database_info:
 
 @pytest.fixture(scope="function")
 def setup_database_relation_invalid_port(
-    harness: ops.testing.Harness, example_invalid_database_info: dict[str, str]
+    harness: ops.testing.Harness, example_invalid_database_info: typing.Dict[str, str]
 ):
     """Yields a function that can be used to set up database relation with a non 3306 port.
 
@@ -196,10 +198,10 @@ def run_standard_plugin_test(
 
     def _run_standard_plugin_test(
         plugin: str,
-        plugin_config: dict[str, str],
-        excepted_options: dict[str, typing.Any],
-        excepted_options_after_removed: dict[str, str] | None = None,
-        additional_check_after_install: typing.Callable | None = None,
+        plugin_config: typing.Dict[str, str],
+        excepted_options: typing.Dict[str, typing.Any],
+        excepted_options_after_removed: typing.Optional[typing.Dict[str, str]] = None,
+        additional_check_after_install: typing.Optional[typing.Callable] = None,
     ):
         """Function to perform standard plugins test.
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -130,7 +130,7 @@ def test_db_relation(
 def test_database_relation(
     harness: ops.testing.Harness,
     setup_database_relation: typing.Callable[[], typing.Tuple[int, dict]],
-    example_database_host_port: tuple[str, str],
+    example_database_host_port: typing.Tuple[str, str],
 ):
     """
     arrange: no pre-condition.

--- a/tests/unit/wordpress_mock.py
+++ b/tests/unit/wordpress_mock.py
@@ -397,7 +397,7 @@ class WordpressContainerMock:
         file_list = []
         for file in self.fs:
             if file.startswith(path):
-                file_list.append(file.removeprefix(path).split("/")[0])
+                file_list.append(file.replace(path, "", 1).split("/")[0])
         return file_list
 
     def remove_path(self, path: str, recursive: bool = False) -> None:


### PR DESCRIPTION
The latest/stable version of loki-k8s charm isn't quite stable due to the missing `can_connect` guard (please refer to https://chat.charmhub.io/charmhub/pl/xgqyman4btym3ff74fcjomzxbw).

This PR proposes to use the latest revision (82) of the loki-k8s charm to resolve the issues with flaky tests.

Other minor improvements include:
- Updating pre-run script to remove duplicate `microk8s enable registry` (already enabled on operator-workflows)
- Updating Required Status Checks action
- Updating libraries
- Updating typing syntax to match Python 3.8
- Updating libraries