### PR TITLE
Remove unused website relation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -51,8 +51,6 @@ resources:
     upstream-source: bitnami/apache-exporter:0.11.0
 
 provides:
-  website:
-    interface: http
   metrics-endpoint:
     interface: prometheus_scrape
   grafana-dashboard:


### PR DESCRIPTION
Remove the unused "website" relation. The charm doesn't implement this in any way, so just remove it. This was likely cargo-culted from the machine version of this charm, but in the k8s world it's not relevant.