### PR TITLE
fix: handle database endpoint changed event

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,8 +19,8 @@ jobs:
       pre-run-script: |
         -c "sudo microk8s enable hostpath-storage
           sudo microk8s kubectl -n kube-system rollout status -w deployment/hostpath-provisioner
-          sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config"
-        -c "chmod +x tests/integration/pre_run_script.sh
+          sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config
+          chmod +x tests/integration/pre_run_script.sh
           ./tests/integration/pre_run_script.sh"
       setup-devstack-swift: true
       trivy-image-config: ./trivy.yaml

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -20,6 +20,8 @@ jobs:
         -c "sudo microk8s enable hostpath-storage
           sudo microk8s kubectl -n kube-system rollout status -w deployment/hostpath-provisioner
           sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config"
+        -c "chmod +x tests/integration/pre_run_script.sh
+          ./tests/integration/pre_run_script.sh"
       setup-devstack-swift: true
       trivy-image-config: ./trivy.yaml
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -175,6 +175,7 @@ class WordpressCharm(CharmBase):
         self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(self.on.uploads_storage_attached, self._reconciliation)
         self.framework.observe(self.database.on.database_created, self._reconciliation)
+        self.framework.observe(self.database.on.endpoints_changed, self._reconciliation)
         self.framework.observe(self.on.config_changed, self._reconciliation)
         self.framework.observe(self.on.upgrade_charm, self._setup_replica_data)
         self.framework.observe(self.on.wordpress_pebble_ready, self._set_version)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -85,7 +85,7 @@ async def wordpress_fixture(
             "wordpress-image": wordpress_image,
             "apache-prometheus-exporter-image": "bitnami/apache-exporter:0.11.0",
         },
-        num_units=2,
+        num_units=1,
         series="focal",
     )
     return WordpressApp(app, ops_test=ops_test, kube_config=kube_config)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,7 +94,7 @@ async def wordpress_fixture(
 @pytest_asyncio.fixture(scope="module")
 async def prepare_mysql(wordpress: WordpressApp, model: Model):
     """Deploy and relate the mysql-k8s charm for integration tests."""
-    await model.deploy("mysql-k8s", channel="8.0/edge", trust=True)
+    await model.deploy("mysql-k8s", channel="8.0/candidate", trust=True)
     await model.wait_for_idle(status="active", apps=["mysql-k8s"], timeout=30 * 60)
     await model.add_relation(f"{wordpress.name}:database", "mysql-k8s:database")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,8 +6,9 @@
 import configparser
 import json
 import re
+import secrets
 from pathlib import Path
-from typing import Dict, Optional
+from typing import AsyncGenerator, Dict, Optional
 
 import kubernetes
 import pytest
@@ -15,6 +16,7 @@ import pytest_asyncio
 import swiftclient
 import swiftclient.exceptions
 import swiftclient.service
+from juju.controller import Controller
 from juju.model import Model
 from pytest import Config
 from pytest_operator.plugin import OpsTest
@@ -30,8 +32,43 @@ def model(ops_test: OpsTest) -> Model:
     return model
 
 
+@pytest.fixture(scope="module", name="kube_config")
+def kube_config_fixture(pytestconfig: Config):
+    """The Kubernetes cluster configuration file."""
+    kube_config = pytestconfig.getoption("--kube-config")
+    assert kube_config, (
+        "The Kubernetes config file path should not be empty, "
+        "please include it in the --kube-config parameter"
+    )
+    return kube_config
+
+
+@pytest_asyncio.fixture(scope="module", name="machine_controller")
+async def machine_controller_fixture() -> AsyncGenerator[Controller, None]:
+    """The lxd controller."""
+    controller = Controller()
+    await controller.connect_controller("localhost")
+
+    yield controller
+
+    await controller.disconnect()
+
+
+@pytest_asyncio.fixture(scope="module", name="machine_model")
+async def machine_model_fixture(machine_controller: Controller) -> AsyncGenerator[Model, None]:
+    """The machine model for jenkins agent machine charm."""
+    machine_model_name = f"mysql-machine-{secrets.token_hex(2)}"
+    model = await machine_controller.add_model(machine_model_name)
+
+    yield model
+
+    await model.disconnect()
+
+
 @pytest_asyncio.fixture(scope="module", name="wordpress")
-async def wordpress_fixture(pytestconfig: Config, ops_test: OpsTest, model: Model) -> WordpressApp:
+async def wordpress_fixture(
+    pytestconfig: Config, ops_test: OpsTest, model: Model, kube_config: str
+) -> WordpressApp:
     """Prepare the wordpress charm for integration tests."""
     charm = pytestconfig.getoption("--charm-file")
     charm_dir = Path(__file__).parent.parent.parent
@@ -51,15 +88,29 @@ async def wordpress_fixture(pytestconfig: Config, ops_test: OpsTest, model: Mode
         num_units=2,
         series="focal",
     )
-    return WordpressApp(app, ops_test=ops_test)
+    return WordpressApp(app, ops_test=ops_test, kube_config=kube_config)
 
 
 @pytest_asyncio.fixture(scope="module")
 async def prepare_mysql(wordpress: WordpressApp, model: Model):
     """Deploy and relate the mysql-k8s charm for integration tests."""
     await model.deploy("mysql-k8s", channel="8.0/edge", trust=True)
-    await model.wait_for_idle(status="active", apps=["mysql-k8s"])
+    await model.wait_for_idle(status="active", apps=["mysql-k8s"], timeout=30 * 60)
     await model.add_relation(f"{wordpress.name}:database", "mysql-k8s:database")
+
+
+@pytest_asyncio.fixture(scope="module")
+async def prepare_machine_mysql(
+    wordpress: WordpressApp, machine_controller: Controller, machine_model: Model, model: Model
+):
+    """Deploy and relate the mysql-k8s charm for integration tests."""
+    await machine_model.deploy("mysql", channel="8.0/edge", trust=True)
+    await machine_model.create_offer("mysql:database")
+    await machine_model.wait_for_idle(status="active", apps=["mysql"], timeout=30 * 60)
+    await model.add_relation(
+        f"{wordpress.name}:database",
+        f"{machine_controller.controller_name}:admin/{machine_model.name}.mysql",
+    )
 
 
 @pytest.fixture(scope="module", name="openstack_environment")
@@ -144,27 +195,18 @@ async def prepare_swift(wordpress: WordpressApp, swift_config: Dict[str, str]):
     await wordpress.set_config(
         {"wp_plugin_openstack-objectstorage_config": json.dumps(swift_config)}
     )
-    await wordpress.model.wait_for_idle(status="active", apps=[wordpress.name])
+    await wordpress.model.wait_for_idle(status="active", apps=[wordpress.name], timeout=30 * 60)
 
 
 @pytest_asyncio.fixture(scope="module")
 async def prepare_nginx_ingress(wordpress: WordpressApp, prepare_mysql):
     """Deploy and relate nginx-ingress-integrator charm for integration tests."""
     await wordpress.model.deploy("nginx-ingress-integrator", series="focal", trust=True)
-    await wordpress.model.wait_for_idle(status="active", apps=["nginx-ingress-integrator"])
+    await wordpress.model.wait_for_idle(
+        status="active", apps=["nginx-ingress-integrator"], timeout=30 * 60
+    )
     await wordpress.model.add_relation(f"{wordpress.name}:nginx-route", "nginx-ingress-integrator")
     await wordpress.model.wait_for_idle(status="active")
-
-
-@pytest.fixture(scope="module", name="kube_config")
-def kube_config_fixture(pytestconfig: Config):
-    """The Kubernetes cluster configuration file."""
-    kube_config = pytestconfig.getoption("--kube-config")
-    assert kube_config, (
-        "The Kubernetes config file path should not be empty, "
-        "please include it in the --kube-config parameter"
-    )
-    return kube_config
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -172,7 +214,7 @@ async def prepare_prometheus(wordpress: WordpressApp, prepare_mysql):
     """Deploy and relate prometheus-k8s charm for integration tests."""
     prometheus = await wordpress.model.deploy("prometheus-k8s", channel="1.0/stable", trust=True)
     await wordpress.model.wait_for_idle(
-        status="active", apps=[prometheus.name], raise_on_error=False
+        status="active", apps=[prometheus.name], raise_on_error=False, timeout=30 * 60
     )
     await wordpress.model.add_relation(f"{wordpress.name}:metrics-endpoint", prometheus.name)
     await wordpress.model.wait_for_idle(

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -37,12 +37,13 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
-def retry(times: int, exceptions: Tuple[Type[Exception]]):
+def retry(times: int, exceptions: Tuple[Type[Exception]], interval=5):
     """Retry decorator to catch exceptions and retry.
 
     Args:
         times: Number of times to retry.
         exceptions: Types of exceptions to catch to retry.
+        interval: Interval between retries.
     """
 
     def decorator(func: Callable):
@@ -72,6 +73,7 @@ def retry(times: int, exceptions: Tuple[Type[Exception]]):
                         times,
                     )
                     attempt += 1
+                time.sleep(interval)
             if asyncio.iscoroutinefunction(func):
                 return await func(*args, **kwargs)
             return func(*args, **kwargs)

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -582,7 +582,7 @@ async def wait_for(
     func: Callable[[], Union[Awaitable, Any]],
     timeout: int = 300,
     check_interval: int = 10,
-) -> None:
+) -> Any:
     """Wait for function execution to become truthy.
 
     Args:
@@ -596,10 +596,10 @@ async def wait_for(
     deadline = time.time() + timeout
     is_awaitable = inspect.iscoroutinefunction(func)
     while time.time() < deadline:
-        if is_awaitable and await func():
-            return
-        if func():
-            return
+        if is_awaitable and (result := await func()):
+            return result
+        if result := func():
+            return result
         time.sleep(check_interval)
     raise TimeoutError()
 

--- a/tests/integration/pre_run_script.sh
+++ b/tests/integration/pre_run_script.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Pre-run script for integration test operator-workflows action.
+# https://github.com/canonical/operator-workflows/blob/main/.github/workflows/integration_test.yaml
+
+# Jenkins machine agent charm is deployed on lxd and Jenkins-k8s server charm is deployed on
+# microk8s.
+
+TESTING_MODEL="$(juju switch)"
+
+# lxd should be install and init by a previous step in integration test action.
+echo "bootstrapping lxd juju controller"
+sg microk8s -c "microk8s status --wait-ready"
+sg microk8s -c "juju bootstrap localhost localhost"
+
+echo "Switching to testing model"
+sg microk8s -c "juju switch $TESTING_MODEL"

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -136,8 +136,7 @@ async def test_database_endpoints_changed(machine_model: Model, wordpress: Wordp
     await machine_model.wait_for_idle(["mysql"], timeout=30 * 60, idle_period=30)
     await model.wait_for_idle(["wordpress-k8s"])
 
-    await wait_for(functools.partial(get_mysql_primary_unit, mysql.units))
-    leader = await get_mysql_primary_unit(mysql.units)
+    leader = await wait_for(functools.partial(get_mysql_primary_unit, mysql.units))
 
     assert (
         await leader.get_public_address() in await wordpress.get_wordpress_config()

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -127,13 +127,13 @@ async def test_database_endpoints_changed(machine_model: Model, wordpress: Wordp
     model: Model = wordpress.model
     mysql: Application = machine_model.applications["mysql"]
     await mysql.add_unit(2)
-    await machine_model.wait_for_idle(["mysql"])
+    await machine_model.wait_for_idle(["mysql"], timeout=30 * 60)
     await model.wait_for_idle(["wordpress-k8s"])
 
     leader = await get_mysql_primary_unit(mysql.units)
     assert leader, "No leader unit found."
     await mysql.destroy_unit(leader.name)
-    await machine_model.wait_for_idle(["mysql"], idle_period=30)
+    await machine_model.wait_for_idle(["mysql"], timeout=30 * 60, idle_period=30)
     await model.wait_for_idle(["wordpress-k8s"])
 
     await wait_for(functools.partial(get_mysql_primary_unit, mysql.units))

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -3,7 +3,6 @@
 
 """Integration tests for WordPress charm core functionality."""
 
-import functools
 import io
 import secrets
 import urllib.parse
@@ -11,9 +10,6 @@ import urllib.parse
 import PIL.Image
 import pytest
 import requests
-from helper import get_mysql_primary_unit, wait_for
-from juju.application import Application
-from juju.model import Model
 
 from charm import WordpressCharm
 from tests.integration.helper import WordpressApp, WordpressClient
@@ -115,29 +111,3 @@ async def test_default_wordpress_themes_and_plugins(wordpress: WordpressApp):
         assert set(wordpress_client.list_plugins()) == set(
             WordpressCharm._WORDPRESS_DEFAULT_PLUGINS
         ), "plugins installed on WordPress should match default plugins defined in charm.py"
-
-
-@pytest.mark.usefixtures("prepare_machine_mysql")
-async def test_database_endpoints_changed(machine_model: Model, wordpress: WordpressApp):
-    """
-    arrange: given related mysql charm with 3 units.
-    act: when the leader mysql unit is removed and hence the endpoints changed event fired.
-    assert: the WordPress correctly connects to the newly elected leader endpoint.
-    """
-    model: Model = wordpress.model
-    mysql: Application = machine_model.applications["mysql"]
-    await mysql.add_unit(2)
-    await machine_model.wait_for_idle(["mysql"], timeout=30 * 60)
-    await model.wait_for_idle(["wordpress-k8s"])
-
-    leader = await get_mysql_primary_unit(mysql.units)
-    assert leader, "No leader unit found."
-    await mysql.destroy_unit(leader.name)
-    await machine_model.wait_for_idle(["mysql"], timeout=30 * 60, idle_period=30)
-    await model.wait_for_idle(["wordpress-k8s"])
-
-    leader = await wait_for(functools.partial(get_mysql_primary_unit, mysql.units))
-
-    assert (
-        await leader.get_public_address() in await wordpress.get_wordpress_config()
-    ), "MySQL leader unit IP not found."

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for WordPress charm core functionality with mysql machine charm."""
+
+import functools
+
+import pytest
+from helper import get_mysql_primary_unit, wait_for
+from juju.application import Application
+from juju.model import Model
+
+from tests.integration.helper import WordpressApp
+
+
+@pytest.mark.usefixtures("prepare_machine_mysql")
+async def test_database_endpoints_changed(machine_model: Model, wordpress: WordpressApp):
+    """
+    arrange: given related mysql charm with 3 units.
+    act: when the leader mysql unit is removed and hence the endpoints changed event fired.
+    assert: the WordPress correctly connects to the newly elected leader endpoint.
+    """
+    model: Model = wordpress.model
+    mysql: Application = machine_model.applications["mysql"]
+    await mysql.add_unit(2)
+    await machine_model.wait_for_idle(["mysql"], timeout=30 * 60)
+    await model.wait_for_idle(["wordpress-k8s"])
+
+    leader = await get_mysql_primary_unit(mysql.units)
+    assert leader, "No leader unit found."
+    await mysql.destroy_unit(leader.name)
+    await machine_model.wait_for_idle(["mysql"], timeout=30 * 60, idle_period=30)
+    await model.wait_for_idle(["wordpress-k8s"])
+
+    leader = await wait_for(functools.partial(get_mysql_primary_unit, mysql.units))
+
+    assert (
+        await leader.get_public_address() in await wordpress.get_wordpress_config()
+    ), "MySQL leader unit IP not found."


### PR DESCRIPTION
Applicable spec: N/A

### Overview

This PR adds a new handler for database endpoints changed. 
Since the handler is a well tested `self.reconcilation` method, the change has been manually tested with the following steps:
1. Deploy 3 units of mysql charm
2. Relate mysql charm with wordpress charm
3. Remove the leader unit of mysql charm (trigger database endpoints changed)
4. WordPress should reconcile and correctly point to the newly elected leader charm.
```
unit-wordpress-k8s-0: 11:31:57 INFO unit.wordpress-k8s/0.juju-log database:2: endpoints changed on 2023-08-24 03:31:57.836105
unit-wordpress-k8s-0: 11:31:57 INFO unit.wordpress-k8s/0.juju-log database:2: Start reconciliation process, triggered by <DatabaseEndpointsChangedEvent via WordpressCharm/DatabaseRequires[database]/on/endpoints_changed[279]>
unit-wordpress-k8s-0: 11:31:57 INFO unit.wordpress-k8s/0.juju-log database:2: Start core reconciliation process
unit-wordpress-k8s-0: 11:31:57 INFO unit.wordpress-k8s/0.juju-log database:2: Changes detected in wp-config.php, updating
unit-wordpress-k8s-0: 11:31:57 INFO unit.wordpress-k8s/0.juju-log database:2: Ensure WordPress (apache) server is down
unit-wordpress-k8s-0: 11:31:57 INFO unit.wordpress-k8s/0.juju-log database:2: Update wp-config.php content in container
unit-wordpress-k8s-0: 11:31:57 INFO unit.wordpress-k8s/0.juju-log database:2: Ensure WordPress server is up
unit-wordpress-k8s-0: 11:31:59 INFO unit.wordpress-k8s/0.juju-log database:2: Wait until the pebble container exists
unit-wordpress-k8s-0: 11:31:59 INFO unit.wordpress-k8s/0.juju-log database:2: Start theme reconciliation process
unit-wordpress-k8s-0: 11:32:14 INFO unit.wordpress-k8s/0.juju-log database:2: Start plugin reconciliation process
unit-wordpress-k8s-0: 11:32:16 INFO unit.wordpress-k8s/0.juju-log database:2: Reconciliation process finished successfully.
unit-wordpress-k8s-0: 11:32:16 INFO juju.worker.uniter.operation ran "database-relation-changed" hook (via hook dispatching script: dispatch)
```

### Rationale

The mysql charm can elect new leaders and hence trigger database endpoints changed event. This will make sure that the  WordPress will be correctly related to a unit that has read/write access.

### Juju Events Changes

- Added a reconcile event handler to react to database's `endpoints_changed` event.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

- This charm requires refactoring to follow the latest charm style guide.
- There is currently an outstanding issue with `src-docs` and libraries. The PR will be issued once it is resolved.
- There is no documentation that requires updating.