### PR TITLE
feat: PR Template & src docs gen

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ Applicable spec: <link>
 
 - [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
 - [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
-- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
+- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
 - [ ] The documentation is generated using `src-docs`
 - [ ] The documentation for charmhub is updated.
 - [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+Applicable spec: <link>
+
+### Overview
+
+<!-- A high level overview of the change -->
+
+### Rationale
+
+<!-- The reason the change is needed -->
+
+### Juju Events Changes
+
+<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
+
+### Module Changes
+
+<!-- Any high level changes to modules and why (Service, Observer, helper) -->
+
+### Library Changes
+
+<!-- Any changes to charm libraries -->
+
+### Checklist
+
+- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
+- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
+- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
+- [ ] The documentation is generated using `src-docs`
+- [ ] The documentation for charmhub is updated.
+- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
+
+<!-- Explanation for any unchecked items above -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Build the OCI image:
+
+```bash
+docker build -t wordpress:test -f wordpress.Dockerfile .
+```
+
+Push the OCI image to microk8s:
+
+```bash
+sudo docker push localhost:32000/wordpress:test
+```
+
+Deploy the charm:
+
+```bash
+charmcraft pack
+juju deploy ./wordpress-k8s_ubuntu-22.04-amd64.charm \
+    --resource jenkins-image=localhost:32000/wordpress:test \
+    --resource apache-prometheus-exporter-image=bitnami/apache-exporter:0.11.0
+```
+
+## Generating src docs for every commit
+
+Run the following command:
+
+```bash
+echo -e "tox -e src-docs\ngit add src-docs\n" > .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```

--- a/generate-src-docs.sh
+++ b/generate-src-docs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+lazydocs --no-watermark --output-path src-docs src/*

--- a/generate-src-docs.sh
+++ b/generate-src-docs.sh
@@ -3,4 +3,4 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-lazydocs --no-watermark --output-path src-docs src/*
+lazydocs --no-watermark --output-path src-docs src/*.py

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -1,0 +1,77 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/charm.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `charm.py`
+Charm for WordPress on kubernetes. 
+
+**Global Variables**
+---------------
+- **APACHE_LOG_PATHS**
+- **WORDPRESS_SCRAPE_JOBS**
+
+
+---
+
+## <kbd>class</kbd> `WordpressCharm`
+Charm for WordPress on kubernetes. 
+
+Attrs:  state: Persistent charm state used to store metadata after various events. 
+
+<a href="../src/charm.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(*args, **kwargs)
+```
+
+Initialize the instance. 
+
+
+
+**Args:**
+ 
+ - <b>`args`</b>:  arguments passed into Charmbase superclass. 
+ - <b>`kwargs`</b>:  keyword arguments passed into Charmbase superclass. 
+
+
+---
+
+#### <kbd>property</kbd> app
+
+Application that this unit is part of. 
+
+---
+
+#### <kbd>property</kbd> charm_dir
+
+Root directory of the charm as it is running. 
+
+---
+
+#### <kbd>property</kbd> config
+
+A mapping containing the charm's config and current values. 
+
+---
+
+#### <kbd>property</kbd> meta
+
+Metadata of this charm. 
+
+---
+
+#### <kbd>property</kbd> model
+
+Shortcut for more simple access the model. 
+
+---
+
+#### <kbd>property</kbd> unit
+
+Unit that this execution is responsible for. 
+
+
+
+

--- a/src-docs/cos.py.md
+++ b/src-docs/cos.py.md
@@ -1,0 +1,40 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/cos.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `cos.py`
+COS integration for WordPress charm. 
+
+**Global Variables**
+---------------
+- **APACHE_PROMETHEUS_SCRAPE_PORT**
+- **WORDPRESS_SCRAPE_JOBS**
+- **APACHE_LOG_PATHS**
+
+
+---
+
+## <kbd>class</kbd> `PrometheusMetricsJob`
+Configuration parameters for prometheus metrics scraping job. 
+
+For more information, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config 
+
+Attrs:  metrics_path: The HTTP resource path on which to fetch metrics from targets.  static_configs: List of labeled statically configured targets for this job. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `PrometheusStaticConfig`
+Configuration parameters for prometheus metrics endpoint scraping. 
+
+For more information, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#static_config 
+
+Attrs:  targets: list of hosts to scrape, e.g. "*:8080", every unit's port 8080  labels: labels assigned to all metrics scraped from the targets. 
+
+
+
+
+

--- a/src-docs/exceptions.py.md
+++ b/src-docs/exceptions.py.md
@@ -1,0 +1,144 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/exceptions.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `exceptions.py`
+User-defined exceptions used by WordPress charm. 
+
+
+
+---
+
+## <kbd>class</kbd> `WordPressBlockedStatusException`
+Same as :exc:`exceptions.WordPressStatusException`. 
+
+<a href="../src/exceptions.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(message: str)
+```
+
+Initialize the instance. 
+
+
+
+**Args:**
+ 
+ - <b>`message`</b>:  A message explaining the reason for given exception. 
+
+
+
+**Raises:**
+ 
+ - <b>`TypeError`</b>:  if same base class is used to instantiate base class. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `WordPressInstallError`
+Exception for unrecoverable errors during WordPress installation. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `WordPressMaintenanceStatusException`
+Same as :exc:`exceptions.WordPressStatusException`. 
+
+<a href="../src/exceptions.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(message: str)
+```
+
+Initialize the instance. 
+
+
+
+**Args:**
+ 
+ - <b>`message`</b>:  A message explaining the reason for given exception. 
+
+
+
+**Raises:**
+ 
+ - <b>`TypeError`</b>:  if same base class is used to instantiate base class. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `WordPressStatusException`
+Exception to signal an early termination of the reconciliation. 
+
+``status`` represents the status change comes with the early termination. Do not instantiate this class directly, use subclass instead. 
+
+<a href="../src/exceptions.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(message: str)
+```
+
+Initialize the instance. 
+
+
+
+**Args:**
+ 
+ - <b>`message`</b>:  A message explaining the reason for given exception. 
+
+
+
+**Raises:**
+ 
+ - <b>`TypeError`</b>:  if same base class is used to instantiate base class. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `WordPressWaitingStatusException`
+Same as :exc:`exceptions.WordPressStatusException`. 
+
+<a href="../src/exceptions.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(message: str)
+```
+
+Initialize the instance. 
+
+
+
+**Args:**
+ 
+ - <b>`message`</b>:  A message explaining the reason for given exception. 
+
+
+
+**Raises:**
+ 
+ - <b>`TypeError`</b>:  if same base class is used to instantiate base class. 
+
+
+
+
+

--- a/src-docs/types_.py.md
+++ b/src-docs/types_.py.md
@@ -1,0 +1,42 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/types_.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `types_.py`
+Module for commonly used internal types in WordPress charm. 
+
+
+
+---
+
+## <kbd>class</kbd> `CommandExecResult`
+Result of executed command from WordPress container. 
+
+Attrs:  return_code: exit code from executed command.  stdout: standard output from the executed command.  stderr: standard error output from the executed command. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `DatabaseConfig`
+Configuration values required to connect to database. 
+
+Attrs:  hostname: The hostname under which the database is being served.  database: The name of the database to connect to.  username: The username to use to authenticate to the database.  password: The password to use to authenticat to the database. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `ExecResult`
+Wrapper for executed command result from WordPress container. 
+
+Attrs:  success: True if command successful, else False.  result: returned value from execution command, parsed in desired format.  message: error message output of executed command. 
+
+
+
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,6 @@ commands =
 
 [testenv:src-docs]
 allowlist_externals=sh
-setenv =
-    PYTHONPATH=src
 description = Generate documentation for src
 deps =
     lazydocs

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
     lazydocs
     -r{toxinidir}/requirements.txt
 commands =
-    ; can't run lazydocs directly due to needing to run it on src/* which produces an invocation error in tox
+    ; can't run lazydocs directly due to needing to run it on src/*.py which produces an invocation error in tox
     sh generate-src-docs.sh
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,18 @@ commands =
     isort {[vars]all_path}
     black {[vars]all_path}
 
+[testenv:src-docs]
+allowlist_externals=sh
+setenv =
+    PYTHONPATH=src
+description = Generate documentation for src
+deps =
+    lazydocs
+    -r{toxinidir}/requirements.txt
+commands =
+    ; can't run lazydocs directly due to needing to run it on src/* which produces an invocation error in tox
+    sh generate-src-docs.sh
+
 [testenv:lint]
 description = Check code against coding style standards
 deps =


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Adds `src-docs` generation to `CONTRIBUTING.md` and `tox.ini`
- Adds PR template

### Rationale

To facilitate PR reviews with lazydocs support & PR template.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

This is does not affect any charm code/behavior. 