### PR TITLE
chore: remove juju version pin

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,5 +1,5 @@
 cosl
-juju==3.0.4
+juju>=2.9,<3
 kubernetes>=25.3,<26
 macaroonbakery==1.3.1
 pillow


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Changes pinned juju dependency for integration test from 3.0.4 to >=2, <3. The integration tests run on juju version 2.9.x, hence the <3.

### Rationale

To use up-to-date juju libs.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
The `src-docs` has a separate PR #115.
There is no documentation change required for Charmhub.