### PR TITLE
Adding sso plugin

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -32,6 +32,8 @@ _\*The descriptions of the following plugins are taken from the WordPress plugin
   Genesis Framework.
 - [line-break-shortcode](https://wordpress.org/plugins/line-break-shortcode/): Shortcode [br] enabler
   for line breaks that will not be filtered out by TinyMCE.
+- [miniorange-saml-20-single-sign-on](https://wordpress.org/plugins/miniorange-saml-20-single-sign-on/): Integrate
+  SAML authentication into you WordPress instance.
 - [no-category-base-wpml](https://wordpress.org/plugins/no-category-base-wpml/): Mandatory
   ‘Category Base’ from category permalinks remover.
 - [openid](https://wordpress.org/plugins/openid/): Authenticator that allows users to authenticate to

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,6 +102,7 @@ class WordpressCharm(CharmBase):
         "genesis-columns-advanced",
         "line-break-shortcode",
         "wp-mastodon-share",
+        "miniorange-saml-20-single-sign-on",
         "no-category-base-wpml",
         "openid",
         "wordpress-launchpad-integration",

--- a/wordpress.Dockerfile
+++ b/wordpress.Dockerfile
@@ -83,6 +83,7 @@ RUN set -e; \
         feedwordpress \
         genesis-columns-advanced \
         line-break-shortcode \
+        miniorange-saml-20-single-sign-on \
         no-category-base-wpml \
         post-grid \
         powerpress \


### PR DESCRIPTION
Applicable spec: <link>

### Overview
Adding the SAML SSO auth plugin to the charm.

### Rationale

It was requested to research if this plugin can be used, and as it can be used perfectly by assigning a custom IDP and pasting the metadata's URL, this PR ensues.

### Juju Events Changes

### Module Changes

The dockerfile now includes the SAML plugin and the charm.py plugin list reflects the change.

### Library Changes

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
