### PR TITLE
Deleting unused db vars

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -147,10 +147,6 @@ class WordpressCharm(CharmBase):
         )
 
         self.state.set_default(
-            relation_db_host=None,
-            relation_db_name=None,
-            relation_db_user=None,
-            relation_db_password=None,
             started=False,
         )
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Remove unused relation db variables.

### Rationale
Cleaning up code

### Juju Events Changes

N/A

### Module Changes
N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
