### PR TITLE
Remove auto-fetch from metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -49,7 +49,6 @@ resources:
   apache-prometheus-exporter-image:
     type: oci-image
     description: Prometheus exporter for apache
-    auto-fetch: true
     upstream-source: bitnami/apache-exporter:0.13.3
 
 provides:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Remove auto-fetch from metadata

### Rationale

auto-fetch has no effect in sidecar charms

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
