### PR TITLE
Fix spacing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # WordPress Operator
 
-A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators)deploying and managing WordPress on Kubernetes. [WordPress](https://wordpress.com) is the world's most popular website builder, and it's free and open-source.
+A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators) deploying and managing WordPress on Kubernetes. [WordPress](https://wordpress.com) is the world's most popular website builder, and it's free and open-source.
 
 This charm simplifies initial deployment and "day N" operations of WordPress on Kubernetes,
 including scaling the number of instances, integration with SSO, 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

A trivial change adding a missing space in the README.

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
