### PR TITLE
fix: increase timeout for wordpress model wait

### DIFF
--- a/tests/integration/test_cos.py
+++ b/tests/integration/test_cos.py
@@ -161,7 +161,7 @@ async def test_grafana_integration(
     )
     await wordpress.model.add_relation("wordpress-k8s:grafana-dashboard", "grafana-k8s")
     await wordpress.model.wait_for_idle(
-        status="active", apps=["grafana-k8s", "wordpress-k8s"], timeout=20 * 60, idle_period=60
+        status="active", apps=["grafana-k8s", "wordpress-k8s"], timeout=30 * 60, idle_period=60
     )
     action: Action = await grafana.units[0].run_action("get-admin-password")
     await action.wait()


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The WordPress integration test times out on COS test. This Pr increases the timeout.

### Rationale

To pass the integration tests.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
