### PR TITLE
Fix the apache configuration test

### DIFF
--- a/tests/unit/wordpress_mock.py
+++ b/tests/unit/wordpress_mock.py
@@ -390,14 +390,16 @@ class WordpressContainerMock:
         """Mock method for :meth:`ops.charm.model.Container.exists`."""
         return path in self.fs
 
-    def list_files(self, path: str) -> typing.List[str]:
+    def list_files(self, path: str):
         """Mock method for :meth:`ops.charm.model.Container.list_files`."""
         if not path.endswith("/"):
             path += "/"
         file_list = []
         for file in self.fs:
             if file.startswith(path):
-                file_list.append(file.replace(path, "", 1).split("/")[0])
+                file_info_mock = unittest.mock.MagicMock()
+                file_info_mock.name = file.replace(path, "", 1).split("/")[0]
+                file_list.append(file_info_mock)
         return file_list
 
     def remove_path(self, path: str, recursive: bool = False) -> None:


### PR DESCRIPTION
### Overview

At present, the `_apache_config_is_enabled` function consistently returns `False`, even when the configuration is enabled. This pull request aims to rectify that issue.

### Rationale

The `_apache_config_is_enabled` function doesn't work as intended.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
