### PR TITLE
Fix linting errors related to requests lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mysql-connector-python
-ops>=2.0.0
-requests
+ops==2.6.0
+requests==2.31.0

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -18,7 +18,7 @@ Charm for WordPress on kubernetes.
 
 Attrs:  state: Persistent charm state used to store metadata after various events. 
 
-<a href="../src/charm.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L137"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -196,7 +196,7 @@ class WordpressClient:
             An instance of :class:`requests.Response`.
         """
         request = requests.Request("GET", url, headers=headers)
-        prepped = request.prepare()
+        prepped = self._session.prepare_request(request)
         response = self._session.send(prepped, timeout=self.timeout)
         if except_status_code is not None and response.status_code != except_status_code:
             raise requests.HTTPError(request=request, response=response)
@@ -230,7 +230,7 @@ class WordpressClient:
             An instance of :class:`requests.Response`.
         """
         request = requests.Request("POST", url, json=json_, data=data, headers=headers)
-        prepped = request.prepare()
+        prepped = self._session.prepare_request(request)
         response = self._session.send(prepped, timeout=self.timeout)
         if except_status_code is not None and response.status_code != except_status_code:
             raise requests.HTTPError(request=request, response=response)

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -195,9 +195,11 @@ class WordpressClient:
         Returns:
             An instance of :class:`requests.Response`.
         """
-        response = self._session.get(url, headers=headers, timeout=self.timeout)
+        request = requests.Request("GET", url, headers=headers)
+        prepped = request.prepare()
+        response = self._session.send(prepped, timeout=self.timeout)
         if except_status_code is not None and response.status_code != except_status_code:
-            raise requests.HTTPError(f"HTTP status {response.status_code}, URL {url} ")
+            raise requests.HTTPError(request=request, response=response)
         return response
 
     def _post(
@@ -227,11 +229,11 @@ class WordpressClient:
         Returns:
             An instance of :class:`requests.Response`.
         """
-        response = self._session.post(
-            url, json=json_, data=data, headers=headers, timeout=self.timeout
-        )
+        request = requests.Request("POST", url, json=json_, data=data, headers=headers)
+        prepped = request.prepare()
+        response = self._session.send(prepped, timeout=self.timeout)
         if except_status_code is not None and response.status_code != except_status_code:
-            raise requests.HTTPError(f"HTTP status {response.status_code}, URL {url} ")
+            raise requests.HTTPError(request=request, response=response)
         return response
 
     def _login(self) -> bool:

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
 allowlist_externals=sh
 description = Generate documentation for src
 deps =
+    cosl
     lazydocs
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->
Fix linting errors related to requests lib and pin some dependencies

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
