### PR TITLE
Add retries to the wp theme list command

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -22,6 +22,7 @@ jobs:
           sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config
           chmod +x tests/integration/pre_run_script.sh
           ./tests/integration/pre_run_script.sh"
+      setup-devstack-swift: true
       trivy-image-config: ./trivy.yaml
 
   integration-test-with-secrets:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -29,40 +29,30 @@ jobs:
     name: Integration Test (With Secrets)
     steps:
       - uses: actions/checkout@v4
-      - run: df -h
-      - run: |
-          sudo du -sh /usr/local/lib/android
-          sudo rm -rf /usr/local/lib/android
+      - run: sudo rm -rf /usr/local/lib/android
       - name: Setup Devstack Swift
         id: setup-devstack-swift
         uses: canonical/setup-devstack-swift@v1
-      - run: df -h
       - name: Create OpenStack credential file
         run: echo "${{ steps.setup-devstack-swift.outputs.credentials }}" > openrc
-      - run: df -h
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-      - run: df -h
       - name: Enable microk8s plugins
         run: |
           sudo microk8s enable hostpath-storage ingress registry
           sudo microk8s kubectl -n kube-system rollout status -w deployment/hostpath-provisioner
           sudo microk8s kubectl -n ingress rollout status -w daemonset.apps/nginx-ingress-microk8s-controller
           sudo microk8s kubectl -n container-registry rollout status -w deployment.apps/registry
-      - run: df -h
       - name: Dump microk8s config
         run: sudo microk8s config > kube-config
-      - run: df -h
       - name: Install tox
         run: python3 -m pip install tox
-      - run: df -h
       - name: Build docker image
         run: |
           docker build -t localhost:32000/wordpress:test -f wordpress.Dockerfile .
           docker push localhost:32000/wordpress:test
-      - run: df -h
       - name: Run integration tests
         run: >
           tox -e integration --

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -24,6 +24,7 @@ jobs:
           ./tests/integration/pre_run_script.sh"
       setup-devstack-swift: true
       trivy-image-config: ./trivy.yaml
+      tmate-debug: true
 
   integration-test-with-secrets:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -22,38 +22,44 @@ jobs:
           sudo microk8s config > ${GITHUB_WORKSPACE}/kube-config
           chmod +x tests/integration/pre_run_script.sh
           ./tests/integration/pre_run_script.sh"
-      setup-devstack-swift: true
       trivy-image-config: ./trivy.yaml
-      tmate-debug: true
 
   integration-test-with-secrets:
     runs-on: ubuntu-latest
     name: Integration Test (With Secrets)
     steps:
       - uses: actions/checkout@v4
+      - run: df -h
       - name: Setup Devstack Swift
         id: setup-devstack-swift
         uses: canonical/setup-devstack-swift@v1
+      - run: df -h
       - name: Create OpenStack credential file
         run: echo "${{ steps.setup-devstack-swift.outputs.credentials }}" > openrc
+      - run: df -h
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+      - run: df -h
       - name: Enable microk8s plugins
         run: |
           sudo microk8s enable hostpath-storage ingress registry
           sudo microk8s kubectl -n kube-system rollout status -w deployment/hostpath-provisioner
           sudo microk8s kubectl -n ingress rollout status -w daemonset.apps/nginx-ingress-microk8s-controller
           sudo microk8s kubectl -n container-registry rollout status -w deployment.apps/registry
+      - run: df -h
       - name: Dump microk8s config
         run: sudo microk8s config > kube-config
+      - run: df -h
       - name: Install tox
         run: python3 -m pip install tox
+      - run: df -h
       - name: Build docker image
         run: |
           docker build -t localhost:32000/wordpress:test -f wordpress.Dockerfile .
           docker push localhost:32000/wordpress:test
+      - run: df -h
       - name: Run integration tests
         run: >
           tox -e integration --

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: df -h
+      - run: |
+          sudo du -sh /usr/local/lib/android
+          sudo rm -rf /usr/local/lib/android
       - name: Setup Devstack Swift
         id: setup-devstack-swift
         uses: canonical/setup-devstack-swift@v1


### PR DESCRIPTION
### Overview

The `feedwordpress` plugin, version `2022.0222`, intermittently causes failures when executing the `wp theme list` command. To address this issue, add retries to the command execution.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
