### PR TITLE
Eliminate mysql-interface variables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,18 +26,6 @@ options:
       default: |
         user_name: admin
         admin_email: devnull@example.com
-  mysql-interface-user:
-    type: string
-    description: >
-      Database username for mysql relation. See mysql-k8s relation documentation at
-      https://charmhub.io/mysql/configure
-    default: ""
-  mysql-interface-database:
-    type: string
-    description: >
-      Database name for mysql relation. See mysql-k8s relation documentation at
-      https://charmhub.io/mysql/configure
-    default: ""
   plugins:
     type: string
     description: |


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Eliminate unused mysql-interface variables

### Rationale

Cleaning up the code from unused code.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
