### PR TITLE
[DPE-2994] No more relational databag usage

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -847,7 +847,7 @@ def test_missing_peer_relation(harness: ops.testing.Harness):
     harness.begin()
     charm: WordpressCharm = typing.cast(WordpressCharm, harness.charm)
     with pytest.raises(WordpressCharm._ReplicaRelationNotReady):
-        charm._replica_relation_data()
+        charm._get_replica_relation_data()
 
 
 @pytest.mark.usefixtures("attach_storage")


### PR DESCRIPTION
### Overview

This PR is addressing issue https://github.com/canonical/wordpress-k8s-operator/issues/163

### Rationale

The Relational Databag is not to be addressed directly but only via interface functions.
Part of the relational data is now "hiding" in Juju Secrets and are not exposed on the databag anymore.
The `data_platform_libs/data_interfaces` `DatabaseRequires` and `DatabaseProvies` interfaces ensure transparent and safe access to all relational data. Outside of these functions, no access/manipulation of this data can be guaranteed in the future.


### Module Changes

Relational Databag usage is replaced with `DatabaseRequires` interface calls.
