### PR TITLE
Fix spacing of apache2 vhost config file

### DIFF
--- a/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
+++ b/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
@@ -21,7 +21,7 @@
 	# Write logs to both files for loki log scraping and stdout for kubernetes
 	# container logs. Required for loki integration.
 	ErrorLog "|$ tee {APACHE_LOG_DIR}/error.log"
-    CustomLog "${APACHE_LOG_DIR}/access.log" combined
+	CustomLog "${APACHE_LOG_DIR}/access.log" combined
 	CustomLog /dev/stdout combined
 
 	# For most configuration files from conf-available/, which are


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Trivial change fixing spacing in apache vhost config file.

### Rationale

To fix spacing to be consistent.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
