### PR TITLE
store and write proxy config to wp-config.php

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ markers = [
 [tool.mypy]
 ignore_missing_imports = true
 allow_redefinition = true
+plugins = ["pydantic.mypy"]
 
 [tool.pylint.'MESSAGES CONTROL']
 disable = "too-few-public-methods,too-many-arguments,too-many-lines,line-too-long,fixme"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mysql-connector-python
 ops==2.8.0
 requests==2.31.0
+pydantic>=1,<2

--- a/src/charm.py
+++ b/src/charm.py
@@ -418,16 +418,14 @@ class WordpressCharm(CharmBase):
 
         wp_config.append("define( 'WP_CACHE', true );")
         if proxy := self._state.proxy_config:
-            if proxy.http_proxy:
-                wp_config.append(
-                    f"define( 'WP_PROXY_HOST',  '{proxy.http_proxy.scheme}://{proxy.http_proxy.host}' );"
-                )
-                wp_config.append(f"define( 'WP_PROXY_PORT',  '{proxy.http_proxy.port}' );")
-            elif proxy.https_proxy:
-                wp_config.append(
-                    f"define( 'WP_PROXY_HOST',  '{proxy.https_proxy.scheme}://{proxy.https_proxy.host}' );"
-                )
-                wp_config.append(f"define( 'WP_PROXY_PORT',  '{proxy.https_proxy.port}' );")
+            if http_proxy := proxy.http_proxy:
+                http_proxy_host = f"{http_proxy.scheme}://{http_proxy.host}"
+                wp_config.append(f"define( 'WP_PROXY_HOST',  '{http_proxy_host}' );")
+                wp_config.append(f"define( 'WP_PROXY_PORT',  '{http_proxy.port}' );")
+            elif https_proxy := proxy.https_proxy:
+                https_proxy_host = f"{https_proxy.scheme}://{https_proxy.host}"
+                wp_config.append(f"define( 'WP_PROXY_HOST',  '{https_proxy_host}' );")
+                wp_config.append(f"define( 'WP_PROXY_PORT',  '{https_proxy.port}' );")
             if proxy.no_proxy:
                 wp_config.append(f"define( 'WP_PROXY_BYPASS_HOSTS',  '{proxy.no_proxy}' );")
         wp_config.append(

--- a/src/charm.py
+++ b/src/charm.py
@@ -417,6 +417,19 @@ class WordpressCharm(CharmBase):
         wp_config.append("define( 'AUTOMATIC_UPDATER_DISABLED', true );")
 
         wp_config.append("define( 'WP_CACHE', true );")
+        if proxy := self._state.proxy_config:
+            if proxy.http_proxy:
+                wp_config.append(
+                    f"define( 'WP_PROXY_HOST',  '{proxy.http_proxy.scheme}://{proxy.http_proxy.host}' );"
+                )
+                wp_config.append(f"define( 'WP_PROXY_PORT',  '{proxy.http_proxy.port}' );")
+            elif proxy.https_proxy:
+                wp_config.append(
+                    f"define( 'WP_PROXY_HOST',  '{proxy.https_proxy.scheme}://{proxy.https_proxy.host}' );"
+                )
+                wp_config.append(f"define( 'WP_PROXY_PORT',  '{proxy.https_proxy.port}' );")
+            if proxy.no_proxy:
+                wp_config.append(f"define( 'WP_PROXY_BYPASS_HOSTS',  '{proxy.no_proxy}' );")
         wp_config.append(
             textwrap.dedent(
                 """\
@@ -429,16 +442,6 @@ class WordpressCharm(CharmBase):
                 """
             )
         )
-
-        if proxy := self._state.proxy_config:
-            if proxy.http_proxy:
-                wp_config.append(f"define( 'WP_PROXY_HOST',  '{proxy.http_proxy}' );")
-                wp_config.append(f"define( 'WP_PROXY_PORT',  '{proxy.http_proxy.port}' );")
-            elif proxy.https_proxy:
-                wp_config.append(f"define( 'WP_PROXY_HOST',  '{proxy.https_proxy}' );")
-                wp_config.append(f"define( 'WP_PROXY_PORT',  '{proxy.https_proxy.port}' );")
-            if proxy.no_proxy:
-                wp_config.append(f"define( 'WP_PROXY_BYPASS_HOSTS',  '{proxy.no_proxy}' );")
 
         return "\n".join(wp_config)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,7 @@ from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from ops.charm import ActionEvent, CharmBase, HookEvent, PebbleReadyEvent, UpgradeCharmEvent
-from ops.framework import EventBase, StoredState
+from ops.framework import EventBase
 from ops.main import main
 from ops.model import (
     ActiveStatus,
@@ -50,11 +50,7 @@ logger = logging.getLogger()
 
 
 class WordpressCharm(CharmBase):
-    """Charm for WordPress on kubernetes.
-
-    Attrs:
-        state: Persistent charm state used to store metadata after various events.
-    """
+    """Charm for WordPress on kubernetes."""
 
     class _ReplicaRelationNotReady(Exception):
         """Replica databag was accessed before peer relations are established."""
@@ -134,8 +130,6 @@ class WordpressCharm(CharmBase):
 
     _DB_CHECK_INTERVAL = 5
     _DB_CHECK_TIMEOUT = 60 * 10
-
-    state = StoredState()
 
     def __init__(self, *args, **kwargs):
         """Initialize the instance.

--- a/src/charm.py
+++ b/src/charm.py
@@ -141,7 +141,7 @@ class WordpressCharm(CharmBase):
         super().__init__(*args, **kwargs)
 
         try:
-            self._state = State.from_charm(self)
+            self.state = State.from_charm(self)
         except CharmConfigInvalidError as exc:
             self.unit.status = ops.BlockedStatus(exc.msg)
             return
@@ -410,7 +410,7 @@ class WordpressCharm(CharmBase):
         wp_config.append("define( 'AUTOMATIC_UPDATER_DISABLED', true );")
 
         wp_config.append("define( 'WP_CACHE', true );")
-        if proxy := self._state.proxy_config:
+        if proxy := self.state.proxy_config:
             if http_proxy := proxy.http_proxy:
                 http_proxy_host = f"{http_proxy.scheme}://{http_proxy.host}"
                 wp_config.append(f"define( 'WP_PROXY_HOST',  '{http_proxy_host}' );")

--- a/src/state.py
+++ b/src/state.py
@@ -59,8 +59,8 @@ class ProxyConfig(BaseModel):
             return None
 
         return cls(
-            http_proxy=tools.parse_obj_as(HttpUrl, http_proxy),
-            https_proxy=tools.parse_obj_as(HttpUrl, https_proxy),
+            http_proxy=tools.parse_obj_as(typing.Optional[HttpUrl], http_proxy),
+            https_proxy=tools.parse_obj_as(typing.Optional[HttpUrl], https_proxy),
             no_proxy=no_proxy,
         )
 

--- a/src/state.py
+++ b/src/state.py
@@ -10,7 +10,7 @@ import typing
 import ops
 
 # pylint: disable=no-name-in-module
-from pydantic import BaseModel, HttpUrl, ValidationError, tools
+from pydantic import BaseModel, HttpUrl, ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +59,8 @@ class ProxyConfig(BaseModel):
             return None
 
         return cls(
-            http_proxy=tools.parse_obj_as(typing.Optional[HttpUrl], http_proxy),
-            https_proxy=tools.parse_obj_as(typing.Optional[HttpUrl], https_proxy),
+            http_proxy=http_proxy,
+            https_proxy=https_proxy,
             no_proxy=no_proxy,
         )
 

--- a/src/state.py
+++ b/src/state.py
@@ -1,0 +1,96 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Wordpress charm state."""
+import dataclasses
+import logging
+import os
+import typing
+
+import ops
+
+# pylint: disable=no-name-in-module
+from pydantic import BaseModel, HttpUrl, ValidationError, tools
+
+logger = logging.getLogger(__name__)
+
+
+class CharmConfigInvalidError(Exception):
+    """Exception raised when a charm configuration is found to be invalid.
+
+    Attributes:
+        msg: Explanation of the error.
+    """
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the CharmConfigInvalidError exception.
+
+        Args:
+            msg: Explanation of the error.
+        """
+        self.msg = msg
+
+
+class ProxyConfig(BaseModel):
+    """Configuration for accessing Jenkins through proxy.
+
+    Attributes:
+        http_proxy: The http proxy URL.
+        https_proxy: The https proxy URL.
+        no_proxy: Comma separated list of hostnames to bypass proxy.
+    """
+
+    http_proxy: typing.Optional[HttpUrl]
+    https_proxy: typing.Optional[HttpUrl]
+    no_proxy: typing.Optional[str]
+
+    @classmethod
+    def from_env(cls) -> typing.Optional["ProxyConfig"]:
+        """Instantiate ProxyConfig from juju charm environment.
+
+        Returns:
+            ProxyConfig if proxy configuration is provided, None otherwise.
+        """
+        http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
+        https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
+        no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
+
+        if not http_proxy and not https_proxy:
+            return None
+
+        return cls(
+            http_proxy=tools.parse_obj_as(HttpUrl, http_proxy),
+            https_proxy=tools.parse_obj_as(HttpUrl, https_proxy),
+            no_proxy=no_proxy,
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class State:
+    """The Wordpress k8s operator charm state.
+
+    Attributes:
+        proxy_config: Proxy configuration to access Jenkins upstream through.
+    """
+
+    proxy_config: typing.Optional[ProxyConfig]
+
+    @classmethod
+    def from_charm(cls, _: ops.CharmBase) -> "State":
+        """Initialize the state from charm.
+
+        Returns:
+            Current state of the charm.
+
+        Raises:
+            CharmConfigInvalidError: if invalid state values were encountered.
+        """
+        try:
+            proxy_config = ProxyConfig.from_env()
+        except ValidationError as exc:
+            logger.error("Invalid juju model proxy configuration, %s", exc)
+            raise CharmConfigInvalidError("Invalid model proxy configuration.") from exc
+
+        return cls(
+            proxy_config=proxy_config,
+        )

--- a/src/state.py
+++ b/src/state.py
@@ -59,8 +59,8 @@ class ProxyConfig(BaseModel):
             return None
 
         return cls(
-            http_proxy=http_proxy,
-            https_proxy=https_proxy,
+            http_proxy=http_proxy if http_proxy else None,
+            https_proxy=https_proxy if https_proxy else None,
             no_proxy=no_proxy,
         )
 

--- a/src/state.py
+++ b/src/state.py
@@ -32,7 +32,7 @@ class CharmConfigInvalidError(Exception):
 
 
 class ProxyConfig(BaseModel):
-    """Configuration for accessing Jenkins through proxy.
+    """Configuration for external access through proxy.
 
     Attributes:
         http_proxy: The http proxy URL.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@
 
 """Fixtures for WordPress charm unit tests."""
 
+import os
 import typing
 import unittest
 import unittest.mock
@@ -314,3 +315,11 @@ def attach_storage(
     patch.container.fs["/proc/mounts"] = "/var/www/html/wp-content/uploads"
     yield
     patch.container.fs["/proc/mounts"] = ""
+
+
+@pytest.fixture(scope="function", name="reset_proxy_env")
+def reset_proxy_env():
+    """Reset proxy related env variables during charm init."""
+    os.environ["JUJU_CHARM_HTTP_PROXY"] = ""
+    os.environ["JUJU_CHARM_HTTPS_PROXY"] = ""
+    os.environ["JUJU_CHARM_NO_PROXY"] = ""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -315,11 +315,3 @@ def attach_storage(
     patch.container.fs["/proc/mounts"] = "/var/www/html/wp-content/uploads"
     yield
     patch.container.fs["/proc/mounts"] = ""
-
-
-@pytest.fixture(scope="function", name="reset_proxy_env")
-def reset_proxy_env():
-    """Reset proxy related env variables during charm init."""
-    os.environ["JUJU_CHARM_HTTP_PROXY"] = ""
-    os.environ["JUJU_CHARM_HTTPS_PROXY"] = ""
-    os.environ["JUJU_CHARM_NO_PROXY"] = ""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,7 +3,6 @@
 
 """Fixtures for WordPress charm unit tests."""
 
-import os
 import typing
 import unittest
 import unittest.mock

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,6 @@
 # pylint:disable=protected-access
 
 import json
-import os
 import typing
 import unittest.mock
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,8 +5,8 @@
 
 # pylint:disable=protected-access
 
-import os
 import json
+import os
 import typing
 import unittest.mock
 
@@ -22,7 +22,6 @@ import types_
 from charm import WordpressCharm
 from exceptions import WordPressBlockedStatusException, WordPressWaitingStatusException
 from tests.unit.wordpress_mock import WordpressContainerMock, WordpressPatch
-from state import CharmConfigInvalidError
 
 BLOCKED_STATUS = "blocked"
 
@@ -882,7 +881,7 @@ def test_wordpress_version_set(harness: ops.testing.Harness):
     assert harness.get_workload_version() == WordpressContainerMock._WORDPRESS_VERSION
 
 
-def test_invalid_proxy_config(harness: ops.testing.Harness):
+def test_valid_proxy_config(harness: ops.testing.Harness):
     """
     arrange: no arrange.
     act: charm container is ready.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -942,7 +942,6 @@ def test_only_valid_http_proxy_config(
     assert all(field in wp_config for field in [TEST_PROXY_HOST, TEST_PROXY_PORT])
 
 
-@pytest.mark.usefixtures("reset_proxy_env")
 def test_only_valid_https_proxy_config(
     harness: ops.testing.Harness,
     setup_replica_consensus: typing.Callable[[], dict],


### PR DESCRIPTION
During `_reconciliation` the charm checks if the themes and plugins currently installed matches the expected themes and plugin. If there are some missing the charm will then download them from `https://wordpress.org`. Behind the scene it runs `wp theme|plugin install` and If the charm is deployed behind a proxy and the proxy information is not present in `wp-config.php` this command will fail, leaving the charm in a blocked state. 

This PR addresses that issue by fetching the proxy information from `juju model-config` and populate the `proxy-config` attribute of the charm state so that the values can be added to `wp-config.php` during reconciliation.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
