### PR TITLE
Remove unused StoredState

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,7 @@ from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from ops.charm import ActionEvent, CharmBase, HookEvent, PebbleReadyEvent, UpgradeCharmEvent
-from ops.framework import EventBase, StoredState
+from ops.framework import EventBase
 from ops.main import main
 from ops.model import (
     ActiveStatus,
@@ -49,11 +49,7 @@ logger = logging.getLogger()
 
 
 class WordpressCharm(CharmBase):
-    """Charm for WordPress on kubernetes.
-
-    Attrs:
-        state: Persistent charm state used to store metadata after various events.
-    """
+    """Charm for WordPress on kubernetes."""
 
     class _ReplicaRelationNotReady(Exception):
         """Replica databag was accessed before peer relations are established."""
@@ -133,8 +129,6 @@ class WordpressCharm(CharmBase):
 
     _DB_CHECK_INTERVAL = 5
     _DB_CHECK_TIMEOUT = 60 * 10
-
-    state = StoredState()
 
     def __init__(self, *args, **kwargs):
         """Initialize the instance.


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Remove unused references to `StoredState`.

### Rationale

The charm was no longer using `StoredState` but still had references to it.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)