### PR TITLE
Mandate host and port in database information

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -603,6 +603,10 @@ class WordpressCharm(CharmBase):
             self.database.fetch_relation_field(relation.id, "endpoints")
         )
         if host is None:
+            logger.warning(
+                "`endpoints` is missing in database relation data: %s",
+                dict(relation.data[relation.app]),
+            )
             return None
         return types_.DatabaseConfig(
             hostname=host,

--- a/src/charm.py
+++ b/src/charm.py
@@ -608,6 +608,8 @@ class WordpressCharm(CharmBase):
         host, port = self._parse_database_endpoints(
             self.database.fetch_relation_field(relation.id, "endpoints")
         )
+        if host is None:
+            return None
         return types_.DatabaseConfig(
             hostname=host,
             port=port,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -879,7 +879,7 @@ def test_wordpress_version_set(harness: ops.testing.Harness):
 
 
 @pytest.mark.usefixtures("attach_storage")
-def test_leader_installation_failure(
+def test_waiting_for_leader_installation_timeout(
     patch: WordpressPatch, harness: ops.testing.Harness, app_name
 ):
     """


### PR DESCRIPTION
### Overview

User feedback indicates that the WordPress charm might initiate the reconciliation process without a database endpoint provided in the database relation, leading to errors during database connectivity verification. Although we haven't been able to replicate this issue, updating the charm to prevent it from proceeding to reconciliation in the absence of a database endpoint in the database relation, as a precautionary measure.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
