### PR TITLE
Move Prometheus exporter to ROCK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,7 @@ Deploy the charm:
 ```bash
 charmcraft pack
 juju deploy ./wordpress-k8s_ubuntu-22.04-amd64.charm \
-    --resource jenkins-image=localhost:32000/wordpress:test \
-    --resource apache-prometheus-exporter-image=bitnami/apache-exporter:0.11.0
+    --resource jenkins-image=localhost:32000/wordpress:test
 ```
 
 ## Generating src docs for every commit

--- a/docs/explanation/containers.md
+++ b/docs/explanation/containers.md
@@ -1,7 +1,6 @@
 # Containers
 
-The core component of wordpress-k8s charm consists of a wordpress-k8s main workload container and a
-`apache-prometheus-exporter` sidecar container. Both services inside the containers are driven by
+The core component of wordpress-k8s charm consists of a wordpress-k8s main workload container with an Apache Prometheus exporter. The services inside the container are driven by
 Pebble, a lightweight API-driven process supervisor that controls the lifecycle of a service.
 Learn more about pebble and its layer configurations [here](https://github.com/canonical/pebble).
 
@@ -34,14 +33,6 @@ pushing Apache server logs to Loki. The configurations for Apache have been set 
 to both `access.log`, `error.log` files and container logs in
 [`000-default.conf`](https://github.com/canonical/wordpress-k8s-operator/blob/main/files/000-default.conf).
 These files are essential for promtail to read and push latest logs to loki periodically.
-
-### apache-prometheus-exporter
-
-This is a sidecar container that contains a golang binary to periodically scrape `/server-status`
-route from the main wordpress container. It exposes WordPress Apache server’s metrics in open
-metrics format on port 9117. It should be noted that some of its own metrics from the Prometheus
-Golang client are exposed that are not part of the WordPress Apache’s metrics and are denoted by
-`go_` prefix.
 
 ### charm
 

--- a/docs/explanation/oci-image.md
+++ b/docs/explanation/oci-image.md
@@ -19,9 +19,3 @@ Currently, WordPress version 5.9.3 is used alongside Ubuntu 20.04 base image. Th
 hasn't yet been upgraded to 22.04 due to an unsupported php version 8 for
 `wordpress-launchpad-integration` plugin (supported php version 7). All other plugins and themes use
 the latest stable version by default, downloaded from the source.
-
-### apache-prometheus-exporter-image
-
-This is the image required for sidecar container apache-prometheus-exporter. Openly available image
-`bitnami/apache-exporter` is used. Read more about the image from the official Docker Hub
-[source](https://hub.docker.com/r/bitnami/apache-exporter/).

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -59,8 +59,7 @@ Deploy the locally built WordPress charm with the following command.
 
 ```
 juju deploy ./wordpress-k8s_ubuntu-22.04-amd64_ubuntu-20.04-amd64.charm \
-  --resource wordpress-image=wordpress \
-  --resource apache-prometheus-exporter-image=bitnami/apache-exporter:0.11.0
+  --resource wordpress-image=wordpress
 ```
 
 You should now be able to see your local wordpress-k8s charm progress through the stages of the

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,8 +30,6 @@ containers:
     mounts:
       - storage: uploads
         location: /var/www/html/wp-content/uploads
-  apache-prometheus-exporter:
-    resource: apache-prometheus-exporter-image
 
 storage:
   uploads:
@@ -46,10 +44,6 @@ resources:
   wordpress-image:
     type: oci-image
     description: OCI image for wordpress
-  apache-prometheus-exporter-image:
-    type: oci-image
-    description: Prometheus exporter for apache
-    upstream-source: bitnami/apache-exporter:0.13.3
 
 provides:
   metrics-endpoint:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -84,7 +84,6 @@ async def wordpress_fixture(
         charm,
         resources={
             "wordpress-image": wordpress_image,
-            "apache-prometheus-exporter-image": "bitnami/apache-exporter:0.11.0",
         },
         num_units=1,
         series="focal",

--- a/wordpress_rock/rockcraft.yaml
+++ b/wordpress_rock/rockcraft.yaml
@@ -74,6 +74,8 @@ parts:
       - WP_VERSION: 6.4.2
     build-packages:
       - curl
+    stage-snaps:
+    - rocks-apache-prometheus-exporter/latest/edge
     override-build: |
       curl -sSL --create-dirs https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o wp
       chmod +x wp


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Install the Apache Prometheus exporter into Wordpress' ROCK

### Rationale

This change simplifies the architecture of the charm by reducing the amount of resources and containers it needs

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
