### PR TITLE
Disable external HTTP request in `wp theme list` and `wp plugin list` command

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -858,7 +858,15 @@ class WordpressCharm(CharmBase):
         # FIXME: the feedwordpress plugin causes the `wp theme list` command to fail occasionally
         # use retries as a temporary workaround for this issue
         for wait in (1, 3, 5, 5, 5):
-            process = self._run_wp_cli(["wp", addon_type, "list", "--format=json"], timeout=600)
+            process = self._run_wp_cli(
+                [
+                    "wp",
+                    addon_type,
+                    "list",
+                    "--exec=define( 'WP_HTTP_BLOCK_EXTERNAL', TRUE );",
+                    "--format=json",
+                ],
+            )
             if process.return_code == 0:
                 break
             time.sleep(wait)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -208,9 +208,7 @@ async def prepare_swift(wordpress: WordpressApp, swift_config: Dict[str, str]):
 async def prepare_nginx_ingress(wordpress: WordpressApp, prepare_mysql):
     """Deploy and relate nginx-ingress-integrator charm for integration tests."""
     await wordpress.model.deploy("nginx-ingress-integrator", series="focal", trust=True)
-    await wordpress.model.wait_for_idle(
-        status="active", apps=["nginx-ingress-integrator"], timeout=30 * 60
-    )
+    await wordpress.model.wait_for_idle(apps=["nginx-ingress-integrator"], timeout=30 * 60)
     await wordpress.model.relate(f"{wordpress.name}:nginx-route", "nginx-ingress-integrator")
     await wordpress.model.wait_for_idle(status="active")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -99,7 +99,7 @@ async def prepare_mysql(ops_test: OpsTest, wordpress: WordpressApp, model: Model
         "deploy", "mysql-k8s", "--channel=8.0/candidate", "--revision=75", "--trust"
     )
     await model.wait_for_idle(status="active", apps=["mysql-k8s"], timeout=30 * 60)
-    await model.add_relation(f"{wordpress.name}:database", "mysql-k8s:database")
+    await model.relate(f"{wordpress.name}:database", "mysql-k8s:database")
     await model.wait_for_idle(
         status="active", apps=["mysql-k8s", wordpress.name], timeout=40 * 60, idle_period=30
     )
@@ -113,7 +113,7 @@ async def prepare_machine_mysql(
     await machine_model.deploy("mysql", channel="8.0/edge", trust=True)
     await machine_model.create_offer("mysql:database")
     await machine_model.wait_for_idle(status="active", apps=["mysql"], timeout=30 * 60)
-    await model.add_relation(
+    await model.relate(
         f"{wordpress.name}:database",
         f"{machine_controller.controller_name}:admin/{machine_model.name}.mysql",
     )
@@ -211,7 +211,7 @@ async def prepare_nginx_ingress(wordpress: WordpressApp, prepare_mysql):
     await wordpress.model.wait_for_idle(
         status="active", apps=["nginx-ingress-integrator"], timeout=30 * 60
     )
-    await wordpress.model.add_relation(f"{wordpress.name}:nginx-route", "nginx-ingress-integrator")
+    await wordpress.model.relate(f"{wordpress.name}:nginx-route", "nginx-ingress-integrator")
     await wordpress.model.wait_for_idle(status="active")
 
 
@@ -224,7 +224,7 @@ async def prepare_prometheus(wordpress: WordpressApp, prepare_mysql):
     await wordpress.model.wait_for_idle(
         status="active", apps=[prometheus.name], raise_on_error=False, timeout=30 * 60
     )
-    await wordpress.model.add_relation(f"{wordpress.name}:metrics-endpoint", prometheus.name)
+    await wordpress.model.relate(f"{wordpress.name}:metrics-endpoint", prometheus.name)
     await wordpress.model.wait_for_idle(
         status="active",
         apps=[prometheus.name, wordpress.name],
@@ -238,7 +238,7 @@ async def prepare_loki(wordpress: WordpressApp, prepare_mysql):
     """Deploy and relate loki-k8s charm for integration tests."""
     loki = await wordpress.model.deploy("loki-k8s", channel="1.0/stable", trust=True)
     await wordpress.model.wait_for_idle(apps=[loki.name], status="active", timeout=20 * 60)
-    await wordpress.model.add_relation(f"{wordpress.name}:logging", loki.name)
+    await wordpress.model.relate(f"{wordpress.name}:logging", loki.name)
     await wordpress.model.wait_for_idle(
         apps=[loki.name, wordpress.name], status="active", timeout=40 * 60
     )


### PR DESCRIPTION
The `wp-cli` commands `wp theme list` and `wp plugin list` by default connect to the WordPress website to check for theme and plugin updates. However, this is unnecessary for the charm's use case and can slow down the command, especially in environments without internet connectivity.

Add `--exec=define('WP_HTTP_BLOCK_EXTERNAL', TRUE);` to disable all external HTTP requests during these two commands. And to my surprise, `--skip-update-check` does not work.