### PR TITLE
Improve WordPress's observability and increase health check timeout

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -152,20 +152,18 @@ class WordpressCharm(CharmBase):
         self._logging = ApacheLogProxyConsumer(
             self, relation_name="logging", log_files=APACHE_LOG_PATHS, container_name="wordpress"
         )
-        prometheus_jobs = [{"static_configs": [{"targets": ["*:9117"]}]}]
+        prometheus_jobs = [
+            {"job_name": "apache_exporter", "static_configs": [{"targets": ["*:9117"]}]}
+        ]
         if self._logging.loki_endpoints:
             prometheus_jobs.append(
                 {
+                    "job_name": "promtail",
                     "static_configs": [
                         {
                             "targets": ["*:9080"],
                         }
                     ],
-                    "metric_relabel_configs": {
-                        "source_labels": ["__name__"],
-                        "regex": "apache_access_log.*",
-                        "action": "keep",
-                    },
                 }
             )
         self.metrics_endpoint = MetricsEndpointProvider(

--- a/src/charm.py
+++ b/src/charm.py
@@ -858,7 +858,15 @@ class WordpressCharm(CharmBase):
         # FIXME: the feedwordpress plugin causes the `wp theme list` command to fail occasionally
         # use retries as a temporary workaround for this issue
         for wait in (1, 3, 5, 5, 5):
-            process = self._run_wp_cli(["wp", addon_type, "list", "--format=json"], timeout=600)
+            process = self._run_wp_cli(
+                [
+                    "wp",
+                    addon_type,
+                    "list",
+                    "--exec=define( 'WP_HTTP_BLOCK_EXTERNAL', TRUE );",
+                    "--format=json",
+                ],
+            )
             if process.return_code == 0:
                 break
             time.sleep(wait)

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,6 @@ import ops.pebble
 import yaml
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
-from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from ops.charm import ActionEvent, CharmBase, HookEvent, PebbleReadyEvent, UpgradeCharmEvent
@@ -40,6 +39,7 @@ from cos import (
     APACHE_LOG_PATHS,
     PROM_EXPORTER_PEBBLE_CONFIG,
     WORDPRESS_SCRAPE_JOBS,
+    ApacheLogProxyConsumer,
 )
 from state import CharmConfigInvalidError, State
 
@@ -154,7 +154,7 @@ class WordpressCharm(CharmBase):
             self,
             jobs=WORDPRESS_SCRAPE_JOBS,
         )
-        self._logging = LogProxyConsumer(
+        self._logging = ApacheLogProxyConsumer(
             self, relation_name="logging", log_files=APACHE_LOG_PATHS, container_name="wordpress"
         )
         self._grafana_dashboards = GrafanaDashboardProvider(self)

--- a/src/charm.py
+++ b/src/charm.py
@@ -153,17 +153,16 @@ class WordpressCharm(CharmBase):
             self, relation_name="logging", log_files=APACHE_LOG_PATHS, container_name="wordpress"
         )
         prometheus_jobs = [
-            {"job_name": "apache_exporter", "static_configs": [{"targets": ["*:9117"]}]}
+            {
+                "job_name": "apache_exporter",
+                "static_configs": [{"targets": ["*:9117"]}],
+            }
         ]
         if self._logging.loki_endpoints:
             prometheus_jobs.append(
                 {
                     "job_name": "promtail",
-                    "static_configs": [
-                        {
-                            "targets": ["*:9080"],
-                        }
-                    ],
+                    "static_configs": [{"targets": ["*:9080"]}],
                 }
             )
         self.metrics_endpoint = MetricsEndpointProvider(

--- a/src/cos.py
+++ b/src/cos.py
@@ -115,7 +115,6 @@ class ApacheLogProxyConsumer(LogProxyConsumer):
                             }
                         }
                     },
-                    {"labelallow": ["request_time_ms"]},
                     {
                         "metrics": {
                             "request_duration_microseconds": {

--- a/src/cos.py
+++ b/src/cos.py
@@ -74,6 +74,24 @@ APACHE_LOG_PATHS = [
     "/var/log/apache2/error.log",
 ]
 
+REQUEST_DURATION_MICROSECONDS_BUCKETS = [
+    10000,
+    25000,
+    50000,
+    100000,
+    200000,
+    300000,
+    400000,
+    500000,
+    750000,
+    1000000,
+    1500000,
+    2000000,
+    2500000,
+    5000000,
+    10000000,
+]
+
 
 class ApacheLogProxyConsumer(LogProxyConsumer):
     """Extends LogProxyConsumer to add a metrics pipeline to promtail."""
@@ -104,25 +122,7 @@ class ApacheLogProxyConsumer(LogProxyConsumer):
                                 "type": "Histogram",
                                 "source": "request_duration_microseconds",
                                 "prefix": "apache_access_log_",
-                                "config": {
-                                    "buckets": [
-                                        10000,
-                                        25000,
-                                        50000,
-                                        100000,
-                                        200000,
-                                        300000,
-                                        400000,
-                                        500000,
-                                        750000,
-                                        1000000,
-                                        1500000,
-                                        2000000,
-                                        2500000,
-                                        5000000,
-                                        10000000,
-                                    ]
-                                },
+                                "config": {"buckets": REQUEST_DURATION_MICROSECONDS_BUCKETS},
                             }
                         }
                     },

--- a/src/cos.py
+++ b/src/cos.py
@@ -135,6 +135,7 @@ class ApacheLogProxyConsumer(LogProxyConsumer):
                             }
                         }
                     },
+                    {"drop": {"expression": ".*"}},
                 ],
             }
         )

--- a/src/cos.py
+++ b/src/cos.py
@@ -113,16 +113,18 @@ class ApacheLogProxyConsumer(LogProxyConsumer):
                             "mapping": {
                                 "request_duration_microseconds": "request_duration_microseconds",
                                 "content_type": "content_type",
+                                "path": "path",
                             }
                         }
                     },
+                    {"labels": {"content_type": "content_type", "path": "path"}},
                     {
                         "match": {
-                            "selector": '!= "/server-status"',
+                            "selector": '{path=~"^/server-status.*$"}',
                             "action": "drop",
                         }
                     },
-                    {"labeldrop": ["filename"]},
+                    {"labeldrop": ["filename", "path"]},
                     {
                         "metrics": {
                             "request_duration_microseconds": {

--- a/src/grafana_dashboards/wordpress.json
+++ b/src/grafana_dashboards/wordpress.json
@@ -28,7 +28,7 @@
   "liveNow": false,
   "panels": [
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -61,7 +61,7 @@
         "content": "# Wordpress Operator for Juju\n\n- Github [URL](https://github.com/canonical/wordpress-k8s-operator)\n\n- For more information, visit wordpress [charmhub](https://charmhub.io/wordpress-k8s)\n\n",
         "mode": "markdown"
       },
-      "pluginVersion": "9.2.1",
+      "pluginVersion": "9.5.3",
       "title": "Wordpress Operator",
       "type": "text"
     },
@@ -126,7 +126,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.1",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -191,7 +191,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.1",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -324,7 +324,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "Access total over rate of 5 min periods",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -373,7 +373,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "reqps"
         },
         "overrides": [
           {
@@ -416,13 +417,13 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "rate(apache_accesses_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])",
+          "expr": "rate(apache_accesses_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Access Total (req / 5min)",
+      "title": "Apache Access Rate",
       "type": "timeseries"
     },
     {
@@ -558,7 +559,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{content_type=~\".+html.*|.+json.*|.+xml.*\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -569,7 +570,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.9, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{content_type=~\".+html.*|.+json.*|.+xml.*\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -581,7 +582,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{content_type=~\".+html.*|.+json.*|.+xml.*\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -593,14 +594,14 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{content_type=~\".+html.*|.+json.*|.+xml.*\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "D"
         }
       ],
-      "title": "Request Duration (percentile)",
+      "title": "Apache Request Duration (percentile)",
       "type": "timeseries"
     },
     {
@@ -656,7 +657,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
@@ -683,7 +685,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_JUJU_COS_244D2E79-63C4-434F-853B-9D7DBCCC307B_PROMETHEUS_0}"
+            "uid": "${prometheusds}"
           },
           "editorMode": "builder",
           "expr": "apache_load{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
@@ -694,7 +696,7 @@
           "refId": "A"
         }
       ],
-      "title": "Apache load (%)",
+      "title": "Apache load",
       "transformations": [
         {
           "id": "renameByRegex",
@@ -863,7 +865,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "KBs"
         },
         "overrides": []
       },
@@ -893,13 +896,13 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "rate(apache_sent_kilobytes_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])",
+          "expr": "rate(apache_sent_kilobytes_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Current total kbytes sent (kb / 5min)",
+      "title": "Apache Sent Rate",
       "transformations": [
         {
           "id": "renameByRegex",
@@ -995,7 +998,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "increase(apache_duration_ms_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]) / increase(apache_accesses_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])",
+          "expr": "increase(apache_duration_ms_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval]) / increase(apache_accesses_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1019,163 +1022,7 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "No data sources found",
-          "value": ""
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "lokids",
-        "options": [],
-        "query": "loki",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "juju_cos_3ffd7d07-d3c0-4dcb-8079-eb8bb5616cff_prometheus-k8s_0",
-          "value": "juju_cos_3ffd7d07-d3c0-4dcb-8079-eb8bb5616cff_prometheus-k8s_0"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "prometheusds",
-        "options": [],
-        "query": "prometheus",
-        "queryValue": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "type": "datasource"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "wordpress-k8s/0",
-          "value": "wordpress-k8s/0"
-        },
-        "datasource": {
-          "uid": "${prometheusds}"
-        },
-        "definition": "label_values(up{juju_model=\"$juju_model\",juju_model_uuid=\"$juju_model_uuid\",juju_application=\"$juju_application\"},juju_unit)",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Juju unit",
-        "multi": false,
-        "name": "juju_unit",
-        "options": [],
-        "query": {
-          "query": "label_values(up{juju_model=\"$juju_model\",juju_model_uuid=\"$juju_model_uuid\",juju_application=\"$juju_application\"},juju_unit)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "wordpress-k8s",
-          "value": "wordpress-k8s"
-        },
-        "datasource": {
-          "uid": "${prometheusds}"
-        },
-        "definition": "label_values(up{juju_model=\"$juju_model\",juju_model_uuid=\"$juju_model_uuid\"},juju_application)",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Juju application",
-        "multi": false,
-        "name": "juju_application",
-        "options": [],
-        "query": {
-          "query": "label_values(up{juju_model=\"$juju_model\",juju_model_uuid=\"$juju_model_uuid\"},juju_application)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "3ffd7d07-d3c0-4dcb-8079-eb8bb5616cff",
-          "value": "3ffd7d07-d3c0-4dcb-8079-eb8bb5616cff"
-        },
-        "datasource": {
-          "uid": "${prometheusds}"
-        },
-        "definition": "label_values(up{juju_model=\"$juju_model\"},juju_model_uuid)",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Juju model uuid",
-        "multi": false,
-        "name": "juju_model_uuid",
-        "options": [],
-        "query": {
-          "query": "label_values(up{juju_model=\"$juju_model\"},juju_model_uuid)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "cos",
-          "value": "cos"
-        },
-        "datasource": {
-          "uid": "${prometheusds}"
-        },
-        "definition": "label_values(up,juju_model)",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Juju model",
-        "multi": false,
-        "name": "juju_model",
-        "options": [],
-        "query": {
-          "query": "label_values(up,juju_model)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      }
-    ]
+    "list": []
   },
   "time": {
     "from": "now-6h",
@@ -1184,6 +1031,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Wordpress Operator Overview",
-  "version": 11,
+  "version": 12,
   "weekStart": ""
 }

--- a/src/grafana_dashboards/wordpress.json
+++ b/src/grafana_dashboards/wordpress.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -480,9 +479,58 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "µs"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "50%"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "90%"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "95%"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "99%"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -490,7 +538,7 @@
         "x": 12,
         "y": 15
       },
-      "id": 25,
+      "id": 27,
       "options": {
         "legend": {
           "calcs": [],
@@ -499,8 +547,8 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
@@ -510,22 +558,49 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "increase(apache_duration_ms_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]) / increase(apache_accesses_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])",
+          "expr": "histogram_quantile(0.50, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
-        }
-      ],
-      "title": "Average Request Duration",
-      "transformations": [
+        },
         {
-          "id": "renameByRegex",
-          "options": {
-            "regex": ".*juju_unit=\"(.*)\".*",
-            "renamePattern": "$1"
-          }
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(apache_access_log_request_duration_microseconds_bucket{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[$__rate_interval])))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
         }
       ],
+      "title": "Request Duration (percentile)",
       "type": "timeseries"
     },
     {
@@ -835,9 +910,112 @@
         }
       ],
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "increase(apache_duration_ms_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]) / increase(apache_accesses_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Request Duration",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": ".*juju_unit=\"(.*)\".*",
+            "renamePattern": "$1"
+          }
+        }
+      ],
+      "type": "timeseries"
     }
   ],
-  "schemaVersion": 37,
+  "refresh": "",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1006,6 +1184,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Wordpress Operator Overview",
-  "version": 10,
+  "version": 11,
   "weekStart": ""
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -208,9 +208,7 @@ async def prepare_swift(wordpress: WordpressApp, swift_config: Dict[str, str]):
 async def prepare_nginx_ingress(wordpress: WordpressApp, prepare_mysql):
     """Deploy and relate nginx-ingress-integrator charm for integration tests."""
     await wordpress.model.deploy("nginx-ingress-integrator", series="focal", trust=True)
-    await wordpress.model.wait_for_idle(
-        status="active", apps=["nginx-ingress-integrator"], timeout=30 * 60
-    )
+    await wordpress.model.wait_for_idle(apps=["nginx-ingress-integrator"], timeout=30 * 60)
     await wordpress.model.relate(f"{wordpress.name}:nginx-route", "nginx-ingress-integrator")
     await wordpress.model.wait_for_idle(status="active")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -99,7 +99,7 @@ async def prepare_mysql(ops_test: OpsTest, wordpress: WordpressApp, model: Model
         "deploy", "mysql-k8s", "--channel=8.0/candidate", "--revision=75", "--trust"
     )
     await model.wait_for_idle(status="active", apps=["mysql-k8s"], timeout=30 * 60)
-    await model.add_relation(f"{wordpress.name}:database", "mysql-k8s:database")
+    await model.relate(f"{wordpress.name}:database", "mysql-k8s:database")
     await model.wait_for_idle(
         status="active", apps=["mysql-k8s", wordpress.name], timeout=40 * 60, idle_period=30
     )
@@ -113,7 +113,7 @@ async def prepare_machine_mysql(
     await machine_model.deploy("mysql", channel="8.0/edge", trust=True)
     await machine_model.create_offer("mysql:database")
     await machine_model.wait_for_idle(status="active", apps=["mysql"], timeout=30 * 60)
-    await model.add_relation(
+    await model.relate(
         f"{wordpress.name}:database",
         f"{machine_controller.controller_name}:admin/{machine_model.name}.mysql",
     )
@@ -211,7 +211,7 @@ async def prepare_nginx_ingress(wordpress: WordpressApp, prepare_mysql):
     await wordpress.model.wait_for_idle(
         status="active", apps=["nginx-ingress-integrator"], timeout=30 * 60
     )
-    await wordpress.model.add_relation(f"{wordpress.name}:nginx-route", "nginx-ingress-integrator")
+    await wordpress.model.relate(f"{wordpress.name}:nginx-route", "nginx-ingress-integrator")
     await wordpress.model.wait_for_idle(status="active")
 
 
@@ -224,7 +224,7 @@ async def prepare_prometheus(wordpress: WordpressApp, prepare_mysql):
     await wordpress.model.wait_for_idle(
         status="active", apps=[prometheus.name], raise_on_error=False, timeout=30 * 60
     )
-    await wordpress.model.add_relation(f"{wordpress.name}:metrics-endpoint", prometheus.name)
+    await wordpress.model.relate(f"{wordpress.name}:metrics-endpoint", prometheus.name)
     await wordpress.model.wait_for_idle(
         status="active",
         apps=[prometheus.name, wordpress.name],
@@ -238,7 +238,7 @@ async def prepare_loki(wordpress: WordpressApp, prepare_mysql):
     """Deploy and relate loki-k8s charm for integration tests."""
     loki = await wordpress.model.deploy("loki-k8s", channel="1.0/stable", trust=True)
     await wordpress.model.wait_for_idle(apps=[loki.name], status="active", timeout=20 * 60)
-    await wordpress.model.add_relation(f"{wordpress.name}:logging", loki.name)
+    await wordpress.model.relate(f"{wordpress.name}:logging", loki.name)
     await wordpress.model.wait_for_idle(
         apps=[loki.name, wordpress.name], status="active", timeout=40 * 60
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -984,7 +984,7 @@ def test_wordpress_promtail_config(harness: ops.testing.Harness):
         for static_config in scrape_config["static_configs"]:
             if "job" in static_config["labels"]:
                 pass
-
+    metrics_name = "request_duration_microseconds"
     assert harness.charm._logging._promtail_config == {
         "clients": [],
         "positions": {"filename": "/opt/promtail/positions.yaml"},
@@ -1021,17 +1021,10 @@ def test_wordpress_promtail_config(harness: ops.testing.Harness):
             {
                 "job_name": "access_log_exporter",
                 "pipeline_stages": [
-                    {
-                        "logfmt": {
-                            "mapping": {
-                                "request_duration_microseconds": "request_duration_microseconds"
-                            }
-                        }
-                    },
-                    {"labelallow": ["request_time_ms"]},
+                    {"logfmt": {"mapping": {metrics_name: metrics_name}}},
                     {
                         "metrics": {
-                            "request_duration_microseconds": {
+                            metrics_name: {
                                 "config": {"buckets": REQUEST_DURATION_MICROSECONDS_BUCKETS},
                                 "prefix": "apache_access_log_",
                                 "source": "request_duration_microseconds",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,6 +17,7 @@ import pytest
 
 import types_
 from charm import WordpressCharm
+from cos import REQUEST_DURATION_MICROSECONDS_BUCKETS
 from exceptions import WordPressBlockedStatusException, WordPressWaitingStatusException
 from tests.unit.wordpress_mock import WordpressContainerMock, WordpressPatch
 
@@ -1031,25 +1032,7 @@ def test_wordpress_promtail_config(harness: ops.testing.Harness):
                     {
                         "metrics": {
                             "request_duration_microseconds": {
-                                "config": {
-                                    "buckets": [
-                                        10000,
-                                        25000,
-                                        50000,
-                                        100000,
-                                        200000,
-                                        300000,
-                                        400000,
-                                        500000,
-                                        750000,
-                                        1000000,
-                                        1500000,
-                                        2000000,
-                                        2500000,
-                                        5000000,
-                                        10000000,
-                                    ]
-                                },
+                                "config": {"buckets": REQUEST_DURATION_MICROSECONDS_BUCKETS},
                                 "prefix": "apache_access_log_",
                                 "source": "request_duration_microseconds",
                                 "type": "Histogram",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,6 +17,7 @@ import pytest
 
 import types_
 from charm import WordpressCharm
+from cos import REQUEST_DURATION_MICROSECONDS_BUCKETS
 from exceptions import WordPressBlockedStatusException, WordPressWaitingStatusException
 from tests.unit.wordpress_mock import WordpressContainerMock, WordpressPatch
 
@@ -1023,34 +1024,18 @@ def test_wordpress_promtail_config(harness: ops.testing.Harness):
                         "logfmt": {
                             "mapping": {
                                 "content_type": "content_type",
+                                "path": "path",
                                 "request_duration_microseconds": "request_duration_microseconds",
                             }
                         }
                     },
-                    {"match": {"action": "drop", "selector": "!= " '"/server-status"'}},
-                    {"labeldrop": ["filename"]},
+                    {"labels": {"content_type": "content_type", "path": "path"}},
+                    {"match": {"action": "drop", "selector": '{path=~"^/server-status.*$"}'}},
+                    {"labeldrop": ["filename", "path"]},
                     {
                         "metrics": {
                             "request_duration_microseconds": {
-                                "config": {
-                                    "buckets": [
-                                        10000,
-                                        25000,
-                                        50000,
-                                        100000,
-                                        200000,
-                                        300000,
-                                        400000,
-                                        500000,
-                                        750000,
-                                        1000000,
-                                        1500000,
-                                        2000000,
-                                        2500000,
-                                        5000000,
-                                        10000000,
-                                    ]
-                                },
+                                "config": {"buckets": REQUEST_DURATION_MICROSECONDS_BUCKETS},
                                 "prefix": "apache_access_log_",
                                 "source": "request_duration_microseconds",
                                 "type": "Histogram",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1042,6 +1042,7 @@ def test_wordpress_promtail_config(harness: ops.testing.Harness):
                             }
                         }
                     },
+                    {"drop": {"expression": ".*"}},
                 ],
                 "static_configs": [{"labels": {"__path__": "/var/log/apache2/access.*.log"}}],
             },

--- a/wordpress_rock/files/etc/apache2/apache2.conf
+++ b/wordpress_rock/files/etc/apache2/apache2.conf
@@ -130,7 +130,10 @@ HostnameLookups Off
 # container, error messages relating to that virtual host will be
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
-#
+
+# send error logs to ${APACHE_LOG_DIR}/error.%Y-%m-%d-%H-%M-%S.log and rotate when size limits are reached
+# prune old log files with pruneerrorlogs
+# `rotatelogs -e` echos logs through to stdout, which will be redirected to stderr (kubernetes container logs)
 ErrorLog "|$ /usr/bin/rotatelogs -e -p /usr/bin/pruneerrorlogs ${APACHE_LOG_DIR}/error.%Y-%m-%d-%H-%M-%S.log 256M 1>&2"
 
 #

--- a/wordpress_rock/files/etc/apache2/apache2.conf
+++ b/wordpress_rock/files/etc/apache2/apache2.conf
@@ -131,7 +131,7 @@ HostnameLookups Off
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog "|$ rotatelogs -e -p /usr/bin/pruneerrorlogs ${APACHE_LOG_DIR}/error.%Y-%m-%d-%H-%M-%S.log 256M 1>&2"
+ErrorLog "|$ /usr/bin/rotatelogs -e -p /usr/bin/pruneerrorlogs ${APACHE_LOG_DIR}/error.%Y-%m-%d-%H-%M-%S.log 256M 1>&2"
 
 #
 # LogLevel: Control the severity of messages logged to the error_log.

--- a/wordpress_rock/files/etc/apache2/apache2.conf
+++ b/wordpress_rock/files/etc/apache2/apache2.conf
@@ -131,7 +131,7 @@ HostnameLookups Off
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog "|$ tee -a ${APACHE_LOG_DIR}/error.log 1>&2"
+ErrorLog "|$ rotatelogs -e -p /usr/bin/pruneerrorlogs ${APACHE_LOG_DIR}/error.%Y-%m-%d-%H-%M-%S.log 256M 1>&2"
 
 #
 # LogLevel: Control the severity of messages logged to the error_log.
@@ -217,7 +217,7 @@ AccessFileName .htaccess
 # Note that the use of %{X-Forwarded-For}i instead of %h is not recommended.
 # Use mod_remoteip instead.
 #
-LogFormat "client_ip=%a time=\"%{%Y-%m-%dT%H:%M:%S}t.%{usec_frac}t%{%z}t\" request=\"%r\" method=%m status=%>s referrer=\"%{Referer}i\" user_agent=\"%{User-agent}i\" response_size=%b request_duration_microseconds=%D hostname=%V" logfmt
+LogFormat "client_ip=%a time=\"%{%Y-%m-%dT%H:%M:%S}t.%{usec_frac}t%{%z}t\" method=%m path=\"%U\" query=\"%q\" status=%>s referrer=\"%{Referer}i\" user_agent=\"%{User-agent}i\" content_type=\"%{Content-Type}o\" response_size=%b request_duration_microseconds=%D hostname=%V" logfmt
 LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
 LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%h %l %u %t \"%r\" %>s %O" common

--- a/wordpress_rock/files/etc/apache2/apache2.conf
+++ b/wordpress_rock/files/etc/apache2/apache2.conf
@@ -217,7 +217,7 @@ AccessFileName .htaccess
 # Note that the use of %{X-Forwarded-For}i instead of %h is not recommended.
 # Use mod_remoteip instead.
 #
-LogFormat "client_ip=%a time=\"%{%Y-%m-%dT%H:%M:%S}t.%{usec_frac}t%{%z}t\" request=\"%r\" method=%m status=%>s referrer=\"%{Referer}i\" user_agent=\"%{User-agent}i\" response_size=%b request_time_ms=%D hostname=%V" logfmt
+LogFormat "client_ip=%a time=\"%{%Y-%m-%dT%H:%M:%S}t.%{usec_frac}t%{%z}t\" request=\"%r\" method=%m status=%>s referrer=\"%{Referer}i\" user_agent=\"%{User-agent}i\" response_size=%b request_duration_microseconds=%D hostname=%V" logfmt
 LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
 LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%h %l %u %t \"%r\" %>s %O" common

--- a/wordpress_rock/files/etc/apache2/apache2.conf
+++ b/wordpress_rock/files/etc/apache2/apache2.conf
@@ -131,7 +131,7 @@ HostnameLookups Off
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog ${APACHE_LOG_DIR}/error.log
+ErrorLog "|$ tee -a ${APACHE_LOG_DIR}/error.log 1>&2"
 
 #
 # LogLevel: Control the severity of messages logged to the error_log.

--- a/wordpress_rock/files/etc/apache2/apache2.conf
+++ b/wordpress_rock/files/etc/apache2/apache2.conf
@@ -217,6 +217,7 @@ AccessFileName .htaccess
 # Note that the use of %{X-Forwarded-For}i instead of %h is not recommended.
 # Use mod_remoteip instead.
 #
+LogFormat "client_ip=%a time=\"%{%Y-%m-%dT%H:%M:%S}t.%{usec_frac}t%{%z}t\" request=\"%r\" method=%m status=%>s referrer=\"%{Referer}i\" user_agent=\"%{User-agent}i\" response_size=%b request_time_ms=%D hostname=%V" logfmt
 LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
 LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%h %l %u %t \"%r\" %>s %O" common

--- a/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
+++ b/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
@@ -17,10 +17,6 @@
 	# modules, e.g.
 	#LogLevel info ssl:warn
 
-	# 2023/02/14
-	# Write logs to both files for loki log scraping and stdout for kubernetes
-	# container logs. Required for loki integration.
-	ErrorLog "|$ tee {APACHE_LOG_DIR}/error.log"
 	CustomLog "${APACHE_LOG_DIR}/access.log" logfmt
 	CustomLog /dev/stdout logfmt
 

--- a/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
+++ b/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
@@ -17,7 +17,11 @@
 	# modules, e.g.
 	#LogLevel info ssl:warn
 
+	# send access logs to ${APACHE_LOG_DIR}/access.%Y-%m-%d-%H-%M-%S.log and rotate when size limits are reached
+	# prune old log files with pruneaccesslogs
 	CustomLog "| /usr/bin/rotatelogs -p /usr/bin/pruneaccesslogs ${APACHE_LOG_DIR}/access.%Y-%m-%d-%H-%M-%S.log 256M" logfmt
+
+	# send access logs to stdout (kubernetes container logs) as well
 	CustomLog /dev/stdout logfmt
 
 	# For most configuration files from conf-available/, which are

--- a/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
+++ b/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
@@ -17,7 +17,7 @@
 	# modules, e.g.
 	#LogLevel info ssl:warn
 
-	CustomLog "${APACHE_LOG_DIR}/access.log" logfmt
+	CustomLog "| rotatelogs -p /usr/bin/pruneaccesslogs ${APACHE_LOG_DIR}/access.%Y-%m-%d-%H-%M-%S.log 256M" logfmt
 	CustomLog /dev/stdout logfmt
 
 	# For most configuration files from conf-available/, which are

--- a/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
+++ b/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
@@ -17,7 +17,7 @@
 	# modules, e.g.
 	#LogLevel info ssl:warn
 
-	CustomLog "| rotatelogs -p /usr/bin/pruneaccesslogs ${APACHE_LOG_DIR}/access.%Y-%m-%d-%H-%M-%S.log 256M" logfmt
+	CustomLog "| /usr/bin/rotatelogs -p /usr/bin/pruneaccesslogs ${APACHE_LOG_DIR}/access.%Y-%m-%d-%H-%M-%S.log 256M" logfmt
 	CustomLog /dev/stdout logfmt
 
 	# For most configuration files from conf-available/, which are

--- a/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
+++ b/wordpress_rock/files/etc/apache2/sites-available/000-default.conf
@@ -21,8 +21,8 @@
 	# Write logs to both files for loki log scraping and stdout for kubernetes
 	# container logs. Required for loki integration.
 	ErrorLog "|$ tee {APACHE_LOG_DIR}/error.log"
-	CustomLog "${APACHE_LOG_DIR}/access.log" combined
-	CustomLog /dev/stdout combined
+	CustomLog "${APACHE_LOG_DIR}/access.log" logfmt
+	CustomLog /dev/stdout logfmt
 
 	# For most configuration files from conf-available/, which are
 	# enabled or disabled at a global level, it is possible to

--- a/wordpress_rock/files/usr/bin/pruneaccesslogs
+++ b/wordpress_rock/files/usr/bin/pruneaccesslogs
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# shellcheck disable=SC2012,SC2046,SC2086
 
 log_pattern="/var/log/apache2/access.*.log"
 max_size=$((4*1024*1024*1024))

--- a/wordpress_rock/files/usr/bin/pruneaccesslogs
+++ b/wordpress_rock/files/usr/bin/pruneaccesslogs
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+log_pattern="/var/log/apache2/access.*.log"
+max_size=$((4*1024*1024*1024))
+
+while [ $(du -cb $log_pattern | tail -n 1 | cut -f1) -gt $max_size ]; do
+    oldest=$(ls $log_pattern | sort | head -n 1)
+    if [ -n "$oldest" ]; then
+        rm -f "$oldest"
+    else
+        break
+    fi
+done

--- a/wordpress_rock/files/usr/bin/pruneerrorlogs
+++ b/wordpress_rock/files/usr/bin/pruneerrorlogs
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# shellcheck disable=SC2012,SC2046,SC2086
 
 log_pattern="/var/log/apache2/error.*.log"
 max_size=$((4*1024*1024*1024))

--- a/wordpress_rock/files/usr/bin/pruneerrorlogs
+++ b/wordpress_rock/files/usr/bin/pruneerrorlogs
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+log_pattern="/var/log/apache2/error.*.log"
+max_size=$((4*1024*1024*1024))
+
+while [ $(du -cb $log_pattern | tail -n 1 | cut -f1) -gt $max_size ]; do
+    oldest=$(ls $log_pattern | sort | head -n 1)
+    if [ -n "$oldest" ]; then
+        rm -f "$oldest"
+    else
+        break
+    fi
+done

--- a/wordpress_rock/rockcraft.yaml
+++ b/wordpress_rock/rockcraft.yaml
@@ -71,7 +71,7 @@ parts:
       - apache2
     plugin: nil
     build-environment:
-      - WP_VERSION: 6.4.2
+      - WP_VERSION: 6.4.3
     build-packages:
       - curl
     stage-snaps:


### PR DESCRIPTION
Improve WordPress's observability by updating the Apache access log format to a structured format, including the sub-millisecond request times and durations in the access log. Introduce a new metric, `apache_access_log_request_duration_microseconds`, a histogram tracking request durations. Unlike metrics available through Apache's `mod_status`, this specific metric is derived from Promtail reading the access log, which means it will only be available when `logging` integration is established. This approach should offer better performance compared to using `logql`.

Update the dashboard with a new panel to visualizes request duration percentiles, providing better insights into WordPress performance issues.

Some other miscellaneous changes include adjusting the WordPress health check timeout from 3 to 5 seconds and upgrading WordPress to patch version `6.4.3`.

<img width="720" alt="Screenshot 2024-02-28 at 23 51 27" src="https://github.com/canonical/wordpress-k8s-operator/assets/18743205/bea4a005-9b40-425a-98d6-c3c6036875f7">
