### PR TITLE
Fix storage mount ownership update process during charm upgrades

### DIFF
--- a/tests/unit/wordpress_mock.py
+++ b/tests/unit/wordpress_mock.py
@@ -394,6 +394,11 @@ class WordpressContainerMock:
 
     def list_files(self, path: str, itself=False):
         """Mock method for :meth:`ops.charm.model.Container.list_files`."""
+        if path == "/var/www/html/wp-content/uploads":
+            file_info_mock = unittest.mock.MagicMock()
+            file_info_mock.user = "_daemon_"
+            file_info_mock.group = "_daemon_"
+            return [file_info_mock]
         if not path.endswith("/"):
             path += "/"
         file_list = []


### PR DESCRIPTION
Currently, when updating the storage mount ownership during the `upgrade-charm` event, the WordPress charm does not account for situations where pebble is not ready. This means that if the `upgrade-charm` event is fired before `wordpress-pebble-ready`, it will cause an error. To avoid this problem, update the process for updating storage ownership.