### PR TITLE
fix: tell type checkers that the config options are strings (trivial)

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -958,7 +958,9 @@ class WordpressCharm(CharmBase):
         current_installed_addons = set(t["name"] for t in exec_result.result)
         logger.debug("Currently installed %s %s", addon_type, current_installed_addons)
         addons_in_config = [
-            t.strip() for t in self.model.config[f"{addon_type}s"].split(",") if t.strip()
+            t.strip()
+            for t in cast(str, self.model.config[f"{addon_type}s"]).split(",")
+            if t.strip()
         ]
         default_addons = (
             self._WORDPRESS_DEFAULT_THEMES
@@ -1156,7 +1158,7 @@ class WordpressCharm(CharmBase):
         Raises:
             WordPressBlockedStatusException: if askimet plugin reconciliation process fails.
         """
-        akismet_key = self.model.config["wp_plugin_akismet_key"].strip()
+        akismet_key = cast(str, self.model.config["wp_plugin_akismet_key"]).strip()
         if not akismet_key:
             result = self._deactivate_plugin(
                 "akismet",
@@ -1215,7 +1217,7 @@ class WordpressCharm(CharmBase):
 
     def _plugin_openid_reconciliation(self) -> None:
         """Reconciliation process for the openid plugin."""
-        openid_team_map = self.model.config["wp_plugin_openid_team_map"].strip()
+        openid_team_map = cast(str, self.model.config["wp_plugin_openid_team_map"]).strip()
         result = None
 
         def check_result():
@@ -1310,7 +1312,7 @@ class WordpressCharm(CharmBase):
         Returns:
             Swift configuration in dict.
         """
-        swift_config_str = self.model.config["wp_plugin_openstack-objectstorage_config"]
+        swift_config_str = cast(str, self.model.config["wp_plugin_openstack-objectstorage_config"])
         required_swift_config_key = [
             "auth-url",
             "bucket",


### PR DESCRIPTION
Applicable spec: N/A

### Overview

<!-- A high level overview of the change -->

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

### Rationale

<!-- The reason the change is needed -->
Covered in the overview.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No docs changes required.