### PR TITLE
Refactor to remove wp eval code

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -8,7 +8,6 @@ Charm for WordPress on kubernetes.
 **Global Variables**
 ---------------
 - **APACHE_LOG_PATHS**
-- **WORDPRESS_SCRAPE_JOBS**
 
 
 ---
@@ -16,9 +15,7 @@ Charm for WordPress on kubernetes.
 ## <kbd>class</kbd> `WordpressCharm`
 Charm for WordPress on kubernetes. 
 
-Attrs:  state: Persistent charm state used to store metadata after various events. 
-
-<a href="../src/charm.py#L137"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L132"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/cos.py.md
+++ b/src-docs/cos.py.md
@@ -8,8 +8,58 @@ COS integration for WordPress charm.
 **Global Variables**
 ---------------
 - **APACHE_PROMETHEUS_SCRAPE_PORT**
-- **WORDPRESS_SCRAPE_JOBS**
 - **APACHE_LOG_PATHS**
+- **REQUEST_DURATION_MICROSECONDS_BUCKETS**
+
+
+---
+
+## <kbd>class</kbd> `ApacheLogProxyConsumer`
+Extends LogProxyConsumer to add a metrics pipeline to promtail. 
+
+
+---
+
+#### <kbd>property</kbd> loki_endpoints
+
+Fetch Loki Push API endpoints sent from LokiPushApiProvider through relation data. 
+
+
+
+**Returns:**
+  A list of dictionaries with Loki Push API endpoints, for instance:  [ 
+ - <b>`{"url"`</b>:  "http://loki1:3100/loki/api/v1/push"}, 
+ - <b>`{"url"`</b>:  "http://loki2:3100/loki/api/v1/push"}, ] 
+
+---
+
+#### <kbd>property</kbd> model
+
+Shortcut for more simple access the model. 
+
+---
+
+#### <kbd>property</kbd> rsyslog_config
+
+Generates a config line for use with rsyslog. 
+
+
+
+**Returns:**
+  The rsyslog config line as a string 
+
+---
+
+#### <kbd>property</kbd> syslog_port
+
+Gets the port on which promtail is listening for syslog. 
+
+
+
+**Returns:**
+  A str representing the port 
+
+
 
 
 ---

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -1,0 +1,112 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/state.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `state.py`
+Wordpress charm state. 
+
+
+
+---
+
+## <kbd>class</kbd> `CharmConfigInvalidError`
+Exception raised when a charm configuration is found to be invalid. 
+
+
+
+**Attributes:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+<a href="../src/state.py#L25"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(msg: str)
+```
+
+Initialize a new instance of the CharmConfigInvalidError exception. 
+
+
+
+**Args:**
+ 
+ - <b>`msg`</b>:  Explanation of the error. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `ProxyConfig`
+Configuration for external access through proxy. 
+
+
+
+**Attributes:**
+ 
+ - <b>`http_proxy`</b>:  The http proxy URL. 
+ - <b>`https_proxy`</b>:  The https proxy URL. 
+ - <b>`no_proxy`</b>:  Comma separated list of hostnames to bypass proxy. 
+
+
+
+
+---
+
+<a href="../src/state.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_env`
+
+```python
+from_env() → Optional[ForwardRef('ProxyConfig')]
+```
+
+Instantiate ProxyConfig from juju charm environment. 
+
+
+
+**Returns:**
+  ProxyConfig if proxy configuration is provided, None otherwise. 
+
+
+---
+
+## <kbd>class</kbd> `State`
+The Wordpress k8s operator charm state. 
+
+
+
+**Attributes:**
+ 
+ - <b>`proxy_config`</b>:  Proxy configuration to access Jenkins upstream through. 
+
+
+
+
+---
+
+<a href="../src/state.py#L78"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_charm`
+
+```python
+from_charm(_: CharmBase) → State
+```
+
+Initialize the state from charm. 
+
+
+
+**Returns:**
+  Current state of the charm. 
+
+
+
+**Raises:**
+ 
+ - <b>`CharmConfigInvalidError`</b>:  if invalid state values were encountered. 
+
+

--- a/src-docs/types_.py.md
+++ b/src-docs/types_.py.md
@@ -23,7 +23,7 @@ Attrs:  return_code: exit code from executed command.  stdout: standard output f
 ## <kbd>class</kbd> `DatabaseConfig`
 Configuration values required to connect to database. 
 
-Attrs:  hostname: The hostname under which the database is being served.  database: The name of the database to connect to.  username: The username to use to authenticate to the database.  password: The password to use to authenticat to the database. 
+Attrs:  hostname: The hostname under which the database is being served.  port: The port which the database is listening on.  database: The name of the database to connect to.  username: The username to use to authenticate to the database.  password: The password to use to authenticat to the database. 
 
 
 

--- a/tests/unit/wordpress_mock.py
+++ b/tests/unit/wordpress_mock.py
@@ -359,7 +359,6 @@ class WordpressContainerMock:
         self._wordpress_database_mock = wordpress_database_mock
         self.installed_plugins = set(WordpressCharm._WORDPRESS_DEFAULT_PLUGINS)
         self.installed_themes = set(WordpressCharm._WORDPRESS_DEFAULT_THEMES)
-        self.wp_eval_history: typing.List[str] = []
 
     def exec(
         self, cmd, user=None, group=None, working_dir=None, combine_stderr=None, timeout=None
@@ -600,13 +599,6 @@ class WordpressContainerMock:
         db = self._current_database()
         option = cmd[3]
         db.delete_option(option)
-        return ExecProcessMock(return_code=0, stdout="", stderr="")
-
-    @_exec_handler.register(lambda cmd: cmd[:2] == ["wp", "eval"])
-    def _mock_wp_eval(self, cmd):
-        """Simulate ``wp eval <php_code>`` command execution in the container."""
-        php_code = cmd[2]
-        self.wp_eval_history.append(php_code)
         return ExecProcessMock(return_code=0, stdout="", stderr="")
 
     @_exec_handler.register(lambda cmd: cmd[0] == "a2enconf")

--- a/wordpress_rock/rockcraft.yaml
+++ b/wordpress_rock/rockcraft.yaml
@@ -153,9 +153,8 @@ parts:
     after:
       - get-wordpress-plugins
     plugin: dump
-    source: https://git.launchpad.net/~javierdelapuente/wordpress-teams-integration
+    source: https://git.launchpad.net/~canonical-sysadmins/wordpress-teams-integration/+git/wordpress-teams-integration
     source-type: git
-    source-branch: allow-wp-option-update-json
     organize:
       "*": /var/www/html/wp-content/plugins/wordpress-teams-integration/
   get-openstack-objectstorage-k8s:

--- a/wordpress_rock/rockcraft.yaml
+++ b/wordpress_rock/rockcraft.yaml
@@ -153,8 +153,9 @@ parts:
     after:
       - get-wordpress-plugins
     plugin: dump
-    source: https://git.launchpad.net/~canonical-sysadmins/wordpress-teams-integration/+git/wordpress-teams-integration
+    source: https://git.launchpad.net/~javierdelapuente/wordpress-teams-integration
     source-type: git
+    source-branch: allow-wp-option-update-json
     organize:
       "*": /var/www/html/wp-content/plugins/wordpress-teams-integration/
   get-openstack-objectstorage-k8s:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Small refactor to remove `wp eval` that runs directly code against the wordpress installation to configure the `wordpress-teams-integration` plugin. 

Instead, to configure options  in the same way in all plugins, use `wp option update` command instead of `eval`. That will make it easier to have generic code, and stop using hardcoded php code to configure options in the plugin.

A change was also needed  in the plugin (already merged):
https://git.launchpad.net/~canonical-sysadmins/wordpress-teams-integration/+git/wordpress-teams-integration/commit/?id=a643325df2e40ad5a34346f93872c47cdaa09051

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
