### PR TITLE
Adjustable Pebble health check timeout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,7 +95,7 @@ options:
       Boolean value denoting whether modsec based WAF should be enabled. Applied if ingress
       relation is available.
   health_check_timeout_seconds:
-    type: integer
+    type: int
     default: 5
     description: >
       This setting specifies the duration, in seconds, that pebble will wait for a WordPress health check to complete

--- a/config.yaml
+++ b/config.yaml
@@ -94,3 +94,9 @@ options:
     description: >
       Boolean value denoting whether modsec based WAF should be enabled. Applied if ingress
       relation is available.
+  health_check_timeout_seconds:
+    type: integer
+    default: 5
+    description: >
+      This setting specifies the duration, in seconds, that pebble will wait for a WordPress health check to complete
+      before timing out. Use this setting to adjust the timeout based on expected system performance and conditions

--- a/src/charm.py
+++ b/src/charm.py
@@ -767,7 +767,7 @@ class WordpressCharm(CharmBase):
                     "override": "replace",
                     "level": "alive",
                     "http": {"url": "http://localhost"},
-                    "timeout": "5s",
+                    "timeout": f"{self.config.get('health_check_timeout_seconds')}s",
                 },
             },
         }


### PR DESCRIPTION
### Overview

Introduce a new configuration option, `health_check_timeout_seconds`, to customize the timeout value for WordPress in Pebble. Operators can use this setting to modify the threshold for health checks, tailoring it to the expected system performance and environmental conditions.

Related to https://github.com/canonical/wordpress-k8s-operator/issues/138

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
