### PR TITLE
Change health check period based on timeout

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -752,7 +752,7 @@ class WordpressCharm(CharmBase):
     def _init_pebble_layer(self):
         """Ensure WordPress layer exists in pebble."""
         logger.debug("Ensure WordPress layer exists in pebble")
-        health_check_timeout = self.config.get('health_check_timeout_seconds')
+        health_check_timeout = self.config.get("health_check_timeout_seconds")
         layer = {
             "summary": "WordPress layer",
             "description": "WordPress server",

--- a/src/charm.py
+++ b/src/charm.py
@@ -752,6 +752,7 @@ class WordpressCharm(CharmBase):
     def _init_pebble_layer(self):
         """Ensure WordPress layer exists in pebble."""
         logger.debug("Ensure WordPress layer exists in pebble")
+        health_check_timeout = self.config.get('health_check_timeout_seconds')
         layer = {
             "summary": "WordPress layer",
             "description": "WordPress server",
@@ -767,7 +768,8 @@ class WordpressCharm(CharmBase):
                     "override": "replace",
                     "level": "alive",
                     "http": {"url": "http://localhost"},
-                    "timeout": f"{self.config.get('health_check_timeout_seconds')}s",
+                    "period": f"{max(10, health_check_timeout*2)}s",
+                    "timeout": f"{health_check_timeout}s",
                 },
             },
         }


### PR DESCRIPTION
### Overview

Change the health check period to be twice the health check timeout value. This is required because Pebble versions below 1.7 need the health check timeout value to be less than the health check period value. And newer Pebble versions will clamp the timeout value to be less than or equal to the health check period.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
