### PR TITLE
Update the tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -32,7 +32,7 @@ Deployment of WordPress requires a relational database. The integration with the
 `mysql` [interface](https://juju.is/docs/sdk/integration) is required by the wordpress-k8s
 charm and hence, [`mysql-k8s`](https://charmhub.io/mysql-k8s) charm will be used.
 
-Start off by deploying the wordpress charm. By default it will deploy the latest stable release of
+Start off by deploying the Wordpress charm. By default it will deploy the latest stable release of
 the wordpress-k8s charm.
 
 ```
@@ -47,17 +47,16 @@ The following commands deploy the mysql-k8s charm and integrate it with the word
 juju deploy mysql-k8s --trust
 
 # 'database' interface is required since mysql-k8s charm provides multiple compatible interfaces
-juju relate wordpress-k8s mysql-k8s:database
+juju integrate wordpress-k8s mysql-k8s:database
 ```
 
 ### Get admin credentials <a name="get-admin-credentials"></a>
 
-After the database has been configured in the
-[Deploy and relate database section](#deploy-and-relate-database), you can now access the WordPress
+After the database has been configured, you can now access the WordPress
 application by accessing the IP of a wordpress-k8s unit. To start managing WordPress as an
 administrator, you need to get the credentials for the admin account.
 
-By running the `get-initial-password` action on a wordpress-k8s unit, juju will read and fetch the
+By running the `get-initial-password` action on a wordpress-k8s unit, Juju will read and fetch the
 admin credentials setup for you. You can use the following command below.
 
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,11 +10,11 @@ The wordpress-k8s charm helps deploy a horizontally scalable WordPress applicati
 also helps operate the charm by liaising with the Canonical Observability Stack (COS). This
 tutorial will walk you through each step of deployment to get a basic WordPress deployment.
 
-## Prerequisites
+## Requirements
 
-To deploy wordpress-k8s charm, you will need a juju bootstrapped with any kubernetes controller.
-To see how to bootstrap your juju installation with microk8s, please refer to the documentation
-on microk8s [installation](https://juju.is/docs/olm/microk8s).
+To deploy wordpress-k8s charm, you will need a Juju bootstrapped with any Kubernetes controller.
+To see how to bootstrap your Juju installation with MicroK8s, please refer to the documentation
+on MicroK8s [installation](https://juju.is/docs/olm/microk8s).
 
 ## Steps
 ### Setting up the tutorial model

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -3,7 +3,7 @@
 ## What you'll do
 
 - Deploy the [wordpress-k8s charm](https://charmhub.io/wordpress-k8s)
-- [Deploy and relate database](#deploy-and-relate-database)
+- [Deploy and integrate database](#deploy-and-integrate-database)
 - [Get admin credentials](#get-admin-credentials)
 
 The wordpress-k8s charm helps deploy a horizontally scalable WordPress application with ease and
@@ -17,10 +17,10 @@ To see how to bootstrap your Juju installation with MicroK8s, please refer to th
 on MicroK8s [installation](https://juju.is/docs/olm/microk8s).
 
 ## Steps
-### Setting up the tutorial model
+### Set up the tutorial model
 
 To easily clean up the resources and to separate your workload from the contents of this tutorial,
-it is recommended to set up a new model with the following command.
+set up a new model with the following command.
 
 ```
 juju add-model wordpress-tutorial
@@ -39,7 +39,7 @@ the wordpress-k8s charm.
 juju deploy wordpress-k8s
 ```
 
-### Deploy and integrate database
+### Deploy and integrate database <a name="deploy-and-integrate-database"></a>
 
 The following commands deploy the mysql-k8s charm and integrate it with the wordpress-k8s charm.
 
@@ -50,7 +50,7 @@ juju deploy mysql-k8s --trust
 juju relate wordpress-k8s mysql-k8s:database
 ```
 
-### Get admin credentials
+### Get admin credentials <a name="#get-admin-credentials"></a>
 
 After the database has been configured in the
 [Deploy and relate database section](#deploy-and-relate-database), you can now access the WordPress
@@ -82,7 +82,7 @@ unit-wordpress-k8s-0:
 You can now access your WordPress application at `http://<UNIT_IP>/wp-login.php` and login with
 username admin and password the action above.
 
-### Cleaning up the environment
+### Clean up the environment
 
 Congratulations! You have successfully finished the wordpress-k8s tutorial. You can now remove the
 model environment that you’ve created using the following command.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,12 +10,13 @@ The wordpress-k8s charm helps deploy a horizontally scalable WordPress applicati
 also helps operate the charm by liaising with the Canonical Observability Stack (COS). This
 tutorial will walk you through each step of deployment to get a basic WordPress deployment.
 
-### Prerequisites
+## Prerequisites
 
 To deploy wordpress-k8s charm, you will need a juju bootstrapped with any kubernetes controller.
 To see how to bootstrap your juju installation with microk8s, please refer to the documentation
 on microk8s [installation](https://juju.is/docs/olm/microk8s).
 
+## Steps
 ### Setting up the tutorial model
 
 To easily clean up the resources and to separate your workload from the contents of this tutorial,

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -50,6 +50,23 @@ juju deploy mysql-k8s --trust
 juju integrate wordpress-k8s mysql-k8s:database
 ```
 
+Run `juju status` to see the current status of the deployment. The output should be similar to the following:
+
+```
+Model               Controller          Cloud/Region        Version  SLA          Timestamp
+wordpress-tutorial  microk8s-localhost  microk8s/localhost  3.5.3    unsupported  18:48:09Z
+
+App            Version                  Status  Scale  Charm          Channel        Rev  Address         Exposed  Message
+mysql-k8s      8.0.37-0ubuntu0.22.04.3  active      1  mysql-k8s      8.0/stable     180  10.152.183.254  no       
+wordpress-k8s  6.4.3                    active      1  wordpress-k8s  latest/stable   87  10.152.183.56   no       
+
+Unit              Workload  Agent  Address       Ports  Message
+mysql-k8s/0*      active    idle   10.1.200.163         Primary
+wordpress-k8s/0*  active    idle   10.1.200.161
+```
+
+The deployment finishes when the status shows "Active".
+
 ### Get admin credentials <a name="get-admin-credentials"></a>
 
 After the database has been configured, you can now access the WordPress

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -83,16 +83,12 @@ juju run wordpress-k8s/0 get-initial-password
 The result should look something similar to the contents below:
 
 ```
-unit-wordpress-k8s-0:
-  UnitId: wordpress-k8s/0
-  id: "6"
-  results:
-    password: <password> # should look something like: XXXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXX
-  status: completed
-  timing:
-    completed: <timestamp>
-    enqueued: <timestamp>
-    started: <timestamp>
+Running operation 1 with 1 task
+  - task 2 on unit-wordpress-k8s-0
+
+Waiting for task 2...
+password: <password> # should look something like: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
 ```
 
 You can now access your WordPress application at `http://<UNIT_IP>/wp-login.php` and login with

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -50,7 +50,7 @@ juju deploy mysql-k8s --trust
 juju relate wordpress-k8s mysql-k8s:database
 ```
 
-### Get admin credentials <a name="#get-admin-credentials"></a>
+### Get admin credentials <a name="get-admin-credentials"></a>
 
 After the database has been configured in the
 [Deploy and relate database section](#deploy-and-relate-database), you can now access the WordPress

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Deploy the Wordpress charm for the first time
 
 ## What you'll do
 


### PR DESCRIPTION
### Overview

Three changes to the tutorial for standardisation among all IS charms. In addition, some smaller changes to fix capitalisation and update the headers. 

### Rationale

1. Update the title to move away from "Quick start"/"Getting started" and follow the convention "Deploy X charm for the first time". (ISD-2256)
2. Update the Prerequisites section to be named Requirements (ISD-2262)
3. Add instructions to check `juju status` and example terminal output from that command. (ISD-2277)

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
