### PR TITLE
Add max_input_time charm config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -116,3 +116,9 @@ options:
     description: >
       This sets the maximum time in seconds a script is allowed to run before it is terminated by the parser.
       https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time
+  max_input_time:
+    type: int
+    default: -1
+    description: >
+      This sets the maximum time in seconds a script is allowed to parse input data, like POST and GET.
+      https://www.php.net/manual/en/info.configuration.php#ini.max-input-time

--- a/src/charm.py
+++ b/src/charm.py
@@ -863,7 +863,12 @@ class WordpressCharm(CharmBase):
             the content of the php.ini file.
         """
         current = self._current_php_ini()
-        php_configs = ["upload_max_filesize", "post_max_size", "max_execution_time"]
+        php_configs = [
+            "upload_max_filesize",
+            "post_max_size",
+            "max_execution_time",
+            "max_input_time",
+        ]
         new = current
         for php_config in php_configs:
             search = f"^{php_config}\\s*=\\s*[^\\s]+"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1108,5 +1108,6 @@ def test_php_ini(
         post_max_size = 32M
         upload_max_filesize = 16M
         max_execution_time = 60
+        max_input_time = -1
         """
     )

--- a/tests/unit/wordpress_mock.py
+++ b/tests/unit/wordpress_mock.py
@@ -366,6 +366,7 @@ class WordpressContainerMock:
                 post_max_size = 8M
                 upload_max_filesize = 2M
                 max_execution_time = 30
+                max_input_time = 60
                 """
             ),
         }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add a new Charm configuration `max_input_time`. Debian sets the default value of `max_input_time` to 60 seconds, but here we choose PHP's default value of `-1`, which uses `max_execution_time` as the maximum processing time.

Fix: https://github.com/canonical/wordpress-k8s-operator/issues/269

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
