### PR TITLE
fix: openid relogin

### DIFF
--- a/tests/integration/test_external.py
+++ b/tests/integration/test_external.py
@@ -72,14 +72,19 @@ async def test_openid_plugin(
         # wordpress-teams-integration has a bug causing desired roles not to be assigned to
         # the user when first-time login. Login twice by creating the WordPressClient client twice
         # for the very first time.
-        for _ in range(2 if idx == 0 else 1):
-            wordpress_client = WordpressClient(
-                host=unit_ip,
-                username=openid_username,
-                password=openid_password,
-                is_admin=True,
-                use_launchpad_login=True,
-            )
+        for attempt in range(2 if idx == 0 else 1):
+            try:
+                wordpress_client = WordpressClient(
+                    host=unit_ip,
+                    username=openid_username,
+                    password=openid_password,
+                    is_admin=True,
+                    use_launchpad_login=True,
+                )
+            except AssertionError:
+                if attempt == 0:
+                    continue
+                raise
         assert (
             "administrator" in wordpress_client.list_roles()
         ), "An launchpad OpenID account should be associated with the WordPress admin user"

--- a/tests/integration/test_external.py
+++ b/tests/integration/test_external.py
@@ -46,7 +46,7 @@ async def test_akismet_plugin(
 
 
 @pytest.mark.requires_secret
-@pytest.mark.usefixtures("prepare_mysql", "prepare_swift")
+@pytest.mark.usefixtures("prepare_mysql")
 async def test_openid_plugin(
     wordpress: WordpressApp,
     pytestconfig: Config,


### PR DESCRIPTION
Applicable spec: N/A

### Overview

fixes test which tries to re-login using the same session and fails because the page returned is different if already logged in.

### Rationale

tests failing

### Juju Events Changes

None

### Module Changes

just integration tests

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [ ] The changelog `docs/changelog.md` is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
Not relevant changelog 