### PR TITLE
Update Contents section in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Thinking about using the WordPress Operator for your next project? [Get in touch
 # Contents
 
 1. [Tutorial](tutorial.md)
-1. [How-to](how-to)
+1. [How-to](how-to/index.md)
   1. [Retrieve initial credentials](how-to/retrieve-initial-credentials.md)
   1. [Configure initial settings](how-to/configure-initial-settings.md)
   1. [Configure hostname](how-to/configure-hostname.md)
@@ -55,4 +55,5 @@ Thinking about using the WordPress Operator for your next project? [Get in touch
   1. [Themes](reference/themes.md)
 1. [Explanation](explanation)
   1. [Charm architecture](explanation/charm-architecture.md)
+  1. [Security](explanation/security-overview.md)
 1. [Changelog](changelog.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Thinking about using the WordPress Operator for your next project? [Get in touch
 # Contents
 
 1. [Tutorial](tutorial.md)
-1. [How-to](how-to/index.md)
+1. [How-to](how-to)
   1. [Retrieve initial credentials](how-to/retrieve-initial-credentials.md)
   1. [Configure initial settings](how-to/configure-initial-settings.md)
   1. [Configure hostname](how-to/configure-hostname.md)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Added the security document into the Contents section.

### Rationale

The security document is missing from the index and won't show up on Charmhub.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The changelog `docs/changelog.md` is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
Documentation will either be updated by discourse-gatekeeper or upon approval of this PR.
Since this is a small doc change, I don't think the changelog needs to be updated.
