### PR TITLE
Update promote_charm.yaml

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -13,6 +13,12 @@ on:
         description: 'Destination Channel'
         options:
         - latest/stable
+      base-channel:
+        type: choice
+        description: 'Base Channel'
+        options:
+        - '22.04'
+        - '20.04'
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -23,4 +29,5 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
+      base-channel: ${{ github.event.inputs.base-channel }}
     secrets: inherit


### PR DESCRIPTION
Applicable spec: <link>

### Overview

This add an option for setting the base since Wordpress charm has both and the current configuration is not working for promoting edge to channel.

<img width="1454" height="696" alt="image" src="https://github.com/user-attachments/assets/a4dde070-f520-48e7-ae75-e9ad5d1b5faf" />


### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
