### PR TITLE
Update starter-pack intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -369,5 +369,5 @@ if os.path.exists('./reuse/substitutions.yaml'):
 
 intersphinx_mapping = {
     'juju': ("https://documentation.ubuntu.com/juju/3.6/", None),
-    'starter-pack': ("https://canonical-starter-pack.readthedocs-hosted.com/latest/", None),
+    'starter-pack': ("https://canonical-starter-pack.readthedocs-hosted.com/stable/", None),
 }


### PR DESCRIPTION
### Overview

Update the intersphinx mapping for https://canonical-starter-pack.readthedocs-hosted.com/stable/

### Rationale

The "latest" version no longer exists, and this change has broken the RTD builds for our PRs. This PR will fix the intersphinx mapping and subsequently our workflows :)

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
No documentation updates required. The change is trivial and not user-relevant, and therefore I didn't update the changelog.