### PR TITLE
Add required token permissions to reusable workflow callers

### DIFF
--- a/.github/workflows/auto_update_libs.yaml
+++ b/.github/workflows/auto_update_libs.yaml
@@ -7,4 +7,8 @@ on:
 jobs:
   auto-update-libs:
     uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     secrets: inherit

--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -6,4 +6,6 @@ on:
 jobs:
   bot_pr_approval:
     uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    permissions:
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -9,4 +9,7 @@ on:
 jobs:
   comment-on-pr:
     uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
+    permissions:
+      pull-requests: write
+      actions: read
     secrets: inherit

--- a/.github/workflows/comment_contributing.yaml
+++ b/.github/workflows/comment_contributing.yaml
@@ -10,4 +10,6 @@ on:
 jobs:
   comment-on-pr:
     uses: canonical/operator-workflows/.github/workflows/comment_contributing.yaml@main
+    permissions:
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   docs-checks:
     uses: canonical/operator-workflows/.github/workflows/docs.yaml@main
+    permissions:
+      contents: read
     secrets: inherit
     with:
       vale-files: '["README.md", "CONTRIBUTING.md"]'

--- a/.github/workflows/docs_rtd.yaml
+++ b/.github/workflows/docs_rtd.yaml
@@ -4,6 +4,8 @@ on:
 jobs:
   rtd-docs-checks:
     uses: canonical/operator-workflows/.github/workflows/docs_rtd.yaml@main
+    permissions:
+      contents: read
     secrets: inherit
     with:
       enable-sphinx-python-dependency-build-checks: false

--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -26,6 +26,8 @@ on:
 jobs:
   promote-charm:
     uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    permissions:
+      contents: write
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      packages: write
     secrets: inherit
     with:
       integration-test-workflow-file: test.yaml

--- a/.github/workflows/spread_docs.yaml
+++ b/.github/workflows/spread_docs.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   tutorial-spread-test:
     uses: canonical/operator-workflows/.github/workflows/docs_spread.yaml@main
+    permissions:
+      contents: read
     secrets: inherit
     with:
       input-file: docs/tutorial.md

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,3 +65,5 @@ jobs:
     - integration-test
     - integration-test-juju3
     uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main
+    permissions:
+      contents: write

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -88,7 +88,16 @@ To manage resources effectively and to separate this tutorial's workload from
 your usual work, create a new model in the MicroK8s controller using the following command:
 
 ```{code-cell} bash
-juju add-model wordpress-tutorial-$(date +%s)
+:tags: [remove-cell]
+
+if [ -n "${CI:-}" ]; then
+  juju destroy-model wordpress-tutorial --force --destroy-storage --no-prompt 2>/dev/null || true
+  microk8s kubectl delete namespace wordpress-tutorial --ignore-not-found=true || true
+fi
+```
+
+```{code-cell} bash
+juju add-model wordpress-tutorial
 ```
 
 ## Deploy the WordPress charm

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -88,7 +88,7 @@ To manage resources effectively and to separate this tutorial's workload from
 your usual work, create a new model in the MicroK8s controller using the following command:
 
 ```{code-cell} bash
-juju add-model wordpress-tutorial
+juju add-model wordpress-tutorial-$(date +%s)
 ```
 
 ## Deploy the WordPress charm

--- a/tests/integration/test_cos_grafana.py
+++ b/tests/integration/test_cos_grafana.py
@@ -31,6 +31,24 @@ def dashboard_exist(loggedin_session: requests.Session, unit_address: str):
     return len(dashboards)
 
 
+def grafana_login_ready(
+    loggedin_session: requests.Session, unit_address: str, password: str
+) -> bool:
+    """Return True when Grafana accepts login, handling transient startup 401s."""
+    response = loggedin_session.post(
+        f"http://{unit_address}:3000/login",
+        json={
+            "user": "admin",
+            "password": password,
+        },
+        timeout=10,
+    )
+    if response.status_code == 401:
+        return False
+    response.raise_for_status()
+    return True
+
+
 @pytest.mark.usefixtures("prepare_mysql")
 async def test_grafana_integration(
     wordpress: WordpressApp,
@@ -53,13 +71,16 @@ async def test_grafana_integration(
     status: FullStatus = await wordpress.model.get_status(filters=[grafana.name])
     for unit in status.applications[grafana.name].units.values():
         sess = requests.session()
-        sess.post(
-            f"http://{unit.address}:3000/login",
-            json={
-                "user": "admin",
-                "password": password,
-            },
-        ).raise_for_status()
+        await wait_for(
+            functools.partial(
+                grafana_login_ready,
+                loggedin_session=sess,
+                unit_address=unit.address,
+                password=password,
+            ),
+            timeout=5 * 60,
+            check_interval=5,
+        )
         await wait_for(
             functools.partial(dashboard_exist, loggedin_session=sess, unit_address=unit.address),
             timeout=60 * 20,


### PR DESCRIPTION
## Summary
Add explicit GITHUB_TOKEN permissions required by canonical/operator-workflows reusable workflows.

## Changes
- Add missing permissions for publish/promote/comment/bot approval/auto-update workflows
- Add explicit contents: read for docs workflow callers
- Scope test workflow permissions for the Allure report job
