### PR TITLE
chore(docs): add sitemap_filename configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,6 +192,8 @@ html_baseurl = f"https://canonical.com/juju/docs/wordpress-k8s-charm/{version}/"
 
 sitemap_url_scheme = '{link}'
 
+sitemap_filename = "doc-sitemap.xml"
+
 # Include `lastmod` dates in the sitemap:
 
 sitemap_show_lastmod = True

--- a/docs/reference/relation-endpoints.md
+++ b/docs/reference/relation-endpoints.md
@@ -58,7 +58,7 @@ Ingress manages external http/https access to services in a Kubernetes cluster.
 The `ingress` relation through [nginx-ingress-integrator](https://charmhub.io/nginx-ingress-integrator)
 charm enables additional `blog_hostname` and `use_nginx_ingress_modesec` configurations that
 provide capabilities such as ModSecurity enabled
-Web Application Firewall ([WAF](https://docs.nginx.com/nginx-waf/)).
+Web Application Firewall ([WAF](https://docs.nginx.com/waf/)).
 
 Note that the
 Kubernetes cluster must already have an nginx ingress controller deployed. Documentation to


### PR DESCRIPTION
#### What this PR does

Adds `sitemap_filename` to `docs/conf.py`.

#### Why we need it

Aligns with recommended sitemap configuration according to https://documentation.ubuntu.com/rtd-proxy/how-to/migrate/#sitemaps

#### Validation

https://canonical-wordpress-k8s-juju-charm--377.com.readthedocs.build/377/doc-sitemap.xml