### PR TITLE
chore(docs): Add documentation status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Publish to edge](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml)
 [![Promote charm](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
-[![Documentation status](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)
+[![Documentation status](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)](https://canonical.com/juju/docs/wordpress-k8s-charm/latest/)
 
 # WordPress operator
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Publish to edge](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml)
 [![Promote charm](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
-[![Documentation status](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/docs_rtd.yaml/badge.svg)](https://canonical.com/juju/docs/wordpress-k8s-charm/latest/)
+[![Documentation status](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)](https://canonical.com/juju/docs/wordpress-k8s-charm/latest/)
 
 # WordPress operator
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Publish to edge](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml)
 [![Promote charm](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
-[![Documentation status](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)](https://canonical.com/juju/docs/wordpress-k8s-charm/latest/)
+[![Documentation status](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)
 
 # WordPress operator
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Publish to edge](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml)
 [![Promote charm](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
-[![Documentation status](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)](https://canonical.com/juju/docs/wordpress-k8s-charm/latest/)
+[![Documentation status](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/docs_rtd.yaml/badge.svg)](https://canonical.com/juju/docs/wordpress-k8s-charm/latest/)
 
 # WordPress operator
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Publish to edge](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/publish_charm.yaml)
 [![Promote charm](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml/badge.svg)](https://github.com/canonical/wordpress-k8s-operator/actions/workflows/promote_charm.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
+[![Documentation status](https://app.readthedocs.com/projects/canonical-wordpress-k8s-juju-charm/badge/?version=latest)](https://canonical.com/juju/docs/wordpress-k8s-charm/latest/)
 
 # WordPress operator
 


### PR DESCRIPTION
#### What this PR does

Adds a documentation status badge to the README.

#### Why we need it

Provides a quick visual check that the documentation is live.

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Rockcraft:** I updated the version

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

