### PR TITLE
test: exercise artifact workflows

### DIFF
--- a/.github/charm-ci-test/artifacts.yaml
+++ b/.github/charm-ci-test/artifacts.yaml
@@ -1,0 +1,4 @@
+version: 1
+rocks:
+  - name: wordpress
+    rockcraft-yaml: ../../wordpress_rock/rockcraft.yaml

--- a/.github/workflows/test-charm-ci-artifact.yml
+++ b/.github/workflows/test-charm-ci-artifact.yml
@@ -1,0 +1,20 @@
+name: Test charm-ci artifact build
+
+on:
+  pull_request:
+    paths:
+      - ".github/charm-ci-test/artifacts.yaml"
+      - ".github/workflows/test-charm-ci-artifact.yml"
+      - "wordpress_rock/**"
+
+jobs:
+  build-artifacts:
+    name: Build WordPress rock with charm-ci branch
+    uses: yanksyoon/charm-ci/.github/workflows/build-artifacts.yml@fix/isd-512-artifact-default
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    with:
+      working-directory: .github/charm-ci-test
+      artifact-retention-days: 30

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       with-uv: true
   integration-test:
     name: Integration Test
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: yanksyoon/operator-workflows/.github/workflows/integration_test.yaml@fix/isd-512-artifact-default
     secrets: inherit
     with:
       extra-arguments: >-
@@ -39,7 +39,7 @@ jobs:
       with-uv: true
   integration-test-juju3:
     name: Integration Test on Juju3
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: yanksyoon/operator-workflows/.github/workflows/integration_test.yaml@fix/isd-512-artifact-default
     secrets: inherit
     with:
       extra-arguments: >-


### PR DESCRIPTION
## Purpose

Temporary validation PR for:

- canonical/operator-workflows#1043 at `yanksyoon/operator-workflows@97fcd39`
- canonical/charm-ci#139 at `yanksyoon/charm-ci@810d15c`

## What it exercises

- Existing WordPress MicroK8s and Juju 3 integration jobs consume the operator-workflows feature branch.
- A focused reusable `charm-ci/build-artifacts.yml` job builds the existing `wordpress_rock` using the pull-request artifact default and 30-day retention.

The charm-ci fixture and workflow are intentionally isolated under `.github/charm-ci-test/` and `test-charm-ci-artifact.yml` for this validation PR.

## Local checks

- `uv run tox -e unit`
- `uv run --project /tmp/charm-ci-fix139 opcli artifacts matrix` from `.github/charm-ci-test`
