### PR TITLE
test: exercise charm-ci #139

### DIFF
--- a/.github/charm-ci-test/artifacts.yaml
+++ b/.github/charm-ci-test/artifacts.yaml
@@ -1,4 +1,0 @@
-version: 1
-rocks:
-  - name: wordpress
-    rockcraft-yaml: ../../wordpress_rock/rockcraft.yaml

--- a/.github/charm-ci-test/artifacts.yaml
+++ b/.github/charm-ci-test/artifacts.yaml
@@ -1,0 +1,4 @@
+version: 1
+rocks:
+  - name: wordpress
+    rockcraft-yaml: ../../wordpress_rock/rockcraft.yaml

--- a/.github/workflows/test-charm-ci-artifact.yml
+++ b/.github/workflows/test-charm-ci-artifact.yml
@@ -1,0 +1,20 @@
+name: Test charm-ci artifact build
+
+on:
+  pull_request:
+    paths:
+      - ".github/charm-ci-test/artifacts.yaml"
+      - ".github/workflows/test-charm-ci-artifact.yml"
+      - "wordpress_rock/**"
+
+jobs:
+  build-artifacts:
+    name: Build WordPress rock with charm-ci branch
+    uses: yanksyoon/charm-ci/.github/workflows/build-artifacts.yml@fix/isd-512-artifact-default
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    with:
+      working-directory: .github/charm-ci-test
+      artifact-retention-days: 30

--- a/.github/workflows/test-charm-ci-artifact.yml
+++ b/.github/workflows/test-charm-ci-artifact.yml
@@ -3,7 +3,7 @@ name: Test charm-ci artifact build
 on:
   pull_request:
     paths:
-      - ".github/charm-ci-test/artifacts.yaml"
+      - "artifacts.yaml"
       - ".github/workflows/test-charm-ci-artifact.yml"
       - "wordpress_rock/**"
 
@@ -16,5 +16,5 @@ jobs:
       packages: write
       actions: read
     with:
-      working-directory: .github/charm-ci-test
+      working-directory: .
       artifact-retention-days: 30

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -1,0 +1,4 @@
+version: 1
+rocks:
+  - name: wordpress
+    rockcraft-yaml: wordpress_rock/rockcraft.yaml


### PR DESCRIPTION
## Purpose

Focused validation for [canonical/charm-ci#139](https://github.com/canonical/charm-ci/pull/139), using `yanksyoon/charm-ci@810d15c`.

## What it exercises

- Calls the feature branch's reusable `build-artifacts.yml` workflow.
- Builds the existing WordPress rock through a focused `artifacts.yaml` fixture.
- Exercises pull-request artifact mode and 30-day artifact retention.

The fixture and workflow are isolated under `.github/charm-ci-test/` and are intended only for this validation PR.

## Local checks

- `uv run --project /tmp/charm-ci-fix139 opcli artifacts matrix` — WordPress rock matrix generated successfully
